### PR TITLE
implemented gamepad control

### DIFF
--- a/launch_nodes.py
+++ b/launch_nodes.py
@@ -11,7 +11,7 @@ def launch_ros2_nodes_and_services():
     """
 
     #Nodes
-    joy_node_command = f"{environment_commands}\nros2 run joy joy_node"
+    joy_node_command = f"{environment_commands}\nros2 run joy game_controller_node"
     rosbridge_command = f"{environment_commands}\nros2 launch rosbridge_server rosbridge_websocket_launch.xml"
     orbbec_camera_command = f"{environment_commands}\nros2 launch orbbec_camera gemini_e.launch.py"
     slam_toolbox_command = f"{environment_commands}\nros2 launch slam_toolbox online_sync_launch.py"

--- a/src/studica_control/CMakeLists.txt
+++ b/src/studica_control/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -43,6 +44,7 @@ set(studica_control_HDRS
   include/studica_control/diff_drive_odometry.h
   include/studica_control/dio_component.h
   include/studica_control/encoder_component.h
+  include/studica_control/gamepad_component.h
   include/studica_control/imu_component.h
   include/studica_control/mecanum_drive_component.h
   include/studica_control/servo_component.h
@@ -53,6 +55,7 @@ set(studica_control_HDRS
 
 set(dependencies 
   "ament_index_cpp" 
+  "geometry_msgs"
   "nav_msgs"
   "rclcpp" 
   "rclcpp_action"
@@ -88,6 +91,10 @@ add_library(encoder_component SHARED src/components/encoder_component.cpp)
 ament_target_dependencies(encoder_component ${dependencies})
 rclcpp_components_register_nodes(encoder_component "studica_control::encoder")
 
+add_library(gamepad_component SHARED src/components/gamepad_component.cpp)
+ament_target_dependencies(gamepad_component ${dependencies})
+rclcpp_components_register_nodes(gamepad_component "studica_control::GamepadController")
+
 add_library(imu_component SHARED src/components/imu_component.cpp)
 ament_target_dependencies(imu_component ${dependencies})
 rclcpp_components_register_nodes(imu_component "studica_control::imu")
@@ -109,7 +116,7 @@ rclcpp_components_register_nodes(sharp_component "studica_control::sharp")
 
 add_library(titan_component SHARED src/components/titan_component.cpp)
 ament_target_dependencies(titan_component ${dependencies})
-rclcpp_components_register_nodes(sharp_component "studica_control::Titan")
+rclcpp_components_register_nodes(titan_component "studica_control::Titan")
 
 add_library(ultrasonic_component SHARED src/components/ultrasonic_component.cpp)
 ament_target_dependencies(ultrasonic_component ${dependencies})
@@ -125,6 +132,7 @@ install(TARGETS
   diff_drive_odometry
   dio_component
   encoder_component
+  gamepad_component
   imu_component
   mecanum_drive_component
   mecanum_drive_odometry
@@ -147,6 +155,7 @@ target_link_libraries(manual_composition
   diff_drive_odometry
   dio_component
   encoder_component
+  gamepad_component
   imu_component
   mecanum_drive_component
   mecanum_drive_odometry
@@ -195,6 +204,7 @@ ament_export_libraries(
   diff_drive_odometry
   dio_component
   encoder_component
+  gamepad_component
   imu_component
   mecanum_drive_component
   servo_component

--- a/src/studica_control/config/params.yaml
+++ b/src/studica_control/config/params.yaml
@@ -67,6 +67,19 @@ control_server:
         port_b: 9
         topic: "encoder"
 
+    gamepad:
+      enabled: true
+      name: "gamepad_controller"
+      cmd_vel_topic: "cmd_vel"
+      linear_scale: 0.7
+      angular_scale: 1.0
+      deadzone: 0.1
+      turbo_multiplier: 1.5
+      axis_linear_x: "left_stick_y"      # Left stick vertical (forward/back)
+      axis_linear_y: "left_stick_x"      # Left stick horizontal (strafe)
+      axis_angular_z: "right_stick_x"    # Right stick horizontal (rotation)
+      button_turbo: "right_bumper"       # R1 button
+
     imu:
       enabled: true
       name: "imu"

--- a/src/studica_control/include/studica_control/gamepad_component.h
+++ b/src/studica_control/include/studica_control/gamepad_component.h
@@ -1,0 +1,55 @@
+#ifndef STUDICA_CONTROL__GAMEPAD_COMPONENT_H_
+#define STUDICA_CONTROL__GAMEPAD_COMPONENT_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+namespace studica_control {
+
+class GamepadController : public rclcpp::Node {
+public:
+    explicit GamepadController(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+    GamepadController(const std::string &name, const std::string &cmd_vel_topic);
+    ~GamepadController();
+
+    static std::shared_ptr<rclcpp::Node> initialize(rclcpp::Node *control);
+
+private:
+    void joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg);
+    void publish_twist();
+
+    // Subscriptions and Publishers
+    rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_publisher_;
+    
+    // Timer for continuous publishing
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    // Control parameters
+    double linear_scale_;
+    double angular_scale_;
+    double deadzone_;
+    
+    // Current movement state
+    double linear_x_;
+    double linear_y_;
+    double angular_z_;
+    
+    // Button/axis mappings (configurable) - semantic names for game_controller_node
+    std::string axis_linear_x_;
+    std::string axis_linear_y_;
+    std::string axis_angular_z_;
+    std::string button_turbo_;
+    
+    bool turbo_mode_;
+    double turbo_multiplier_;
+};
+
+} // namespace studica_control
+
+#endif // STUDICA_CONTROL__GAMEPAD_COMPONENT_H_

--- a/src/studica_control/src/components/gamepad_component.cpp
+++ b/src/studica_control/src/components/gamepad_component.cpp
@@ -1,0 +1,141 @@
+#include "studica_control/gamepad_component.h"
+
+namespace studica_control {
+
+std::shared_ptr<rclcpp::Node> GamepadController::initialize(rclcpp::Node *control) {
+    control->declare_parameter<std::string>("gamepad.name", "gamepad_controller");
+    control->declare_parameter<std::string>("gamepad.cmd_vel_topic", "cmd_vel");
+    
+    std::string name = control->get_parameter("gamepad.name").as_string();
+    std::string cmd_vel_topic = control->get_parameter("gamepad.cmd_vel_topic").as_string();
+    
+    auto gamepad = std::make_shared<GamepadController>(name, cmd_vel_topic);
+    return gamepad;
+}
+
+GamepadController::GamepadController(const rclcpp::NodeOptions &options) 
+    : Node("gamepad_controller", options) {}
+
+GamepadController::GamepadController(const std::string &name, const std::string &cmd_vel_topic) 
+    : rclcpp::Node(name), linear_x_(0.0), linear_y_(0.0), angular_z_(0.0), turbo_mode_(false) {
+    
+    // Declare parameters with defaults
+    this->declare_parameter<double>("linear_scale", 0.7);
+    this->declare_parameter<double>("angular_scale", 1.0);
+    this->declare_parameter<double>("deadzone", 0.1);
+    this->declare_parameter<double>("turbo_multiplier", 1.5);
+    // PS4 Controller semantic mappings (game_controller_node)
+    this->declare_parameter<std::string>("axis_linear_x", "left_stick_y");      // Left stick vertical
+    this->declare_parameter<std::string>("axis_linear_y", "left_stick_x");      // Left stick horizontal  
+    this->declare_parameter<std::string>("axis_angular_z", "right_stick_x");    // Right stick horizontal
+    this->declare_parameter<std::string>("button_turbo", "right_bumper");       // R1 button
+    
+    // Get parameters
+    linear_scale_ = this->get_parameter("linear_scale").as_double();
+    angular_scale_ = this->get_parameter("angular_scale").as_double();
+    deadzone_ = this->get_parameter("deadzone").as_double();
+    turbo_multiplier_ = this->get_parameter("turbo_multiplier").as_double();
+    axis_linear_x_ = this->get_parameter("axis_linear_x").as_string();
+    axis_linear_y_ = this->get_parameter("axis_linear_y").as_string();
+    axis_angular_z_ = this->get_parameter("axis_angular_z").as_string();
+    button_turbo_ = this->get_parameter("button_turbo").as_string();
+    
+    // Create subscription to joy topic
+    joy_subscription_ = this->create_subscription<sensor_msgs::msg::Joy>(
+        "joy", 10, std::bind(&GamepadController::joy_callback, this, std::placeholders::_1));
+    
+    // Create publisher for cmd_vel
+    cmd_vel_publisher_ = this->create_publisher<geometry_msgs::msg::Twist>(cmd_vel_topic, 10);
+    
+    // Create timer for continuous publishing (10Hz)
+    timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(100),
+        std::bind(&GamepadController::publish_twist, this));
+    
+    RCLCPP_INFO(this->get_logger(), "Gamepad controller initialized. Publishing to: %s", cmd_vel_topic.c_str());
+    RCLCPP_INFO(this->get_logger(), "PS4 Controls: %s/%s = movement, %s = rotation, %s = turbo", 
+                axis_linear_x_.c_str(), axis_linear_y_.c_str(), axis_angular_z_.c_str(), button_turbo_.c_str());
+}
+
+GamepadController::~GamepadController() {}
+
+void GamepadController::joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg) {
+    // Helper function to get axis value by name from Joy message
+    auto get_axis_value = [&](const std::string& axis_name) -> double {
+        // For game_controller_node, we need to map semantic names to indices
+        // This is a simplified mapping for PS4 controller
+        if (axis_name == "left_stick_x") return msg->axes.size() > 0 ? msg->axes[0] : 0.0;
+        if (axis_name == "left_stick_y") return msg->axes.size() > 1 ? msg->axes[1] : 0.0;
+        if (axis_name == "right_stick_x") return msg->axes.size() > 2 ? msg->axes[2] : 0.0;
+        if (axis_name == "right_stick_y") return msg->axes.size() > 3 ? msg->axes[3] : 0.0;
+        return 0.0;
+    };
+    
+    auto get_button_value = [&](const std::string& button_name) -> bool {
+        // Simplified mapping for PS4 controller buttons
+        if (button_name == "right_bumper") return msg->buttons.size() > 5 ? msg->buttons[5] : false;
+        if (button_name == "left_bumper") return msg->buttons.size() > 4 ? msg->buttons[4] : false;
+        return false;
+    };
+    
+    // Get raw axis values using semantic names
+    double raw_linear_x = get_axis_value(axis_linear_x_);
+    double raw_linear_y = get_axis_value(axis_linear_y_);
+    double raw_angular_z = get_axis_value(axis_angular_z_);
+    
+    // Apply deadzone
+    auto apply_deadzone = [this](double value) {
+        return (std::abs(value) < deadzone_) ? 0.0 : value;
+    };
+    
+    linear_x_ = apply_deadzone(raw_linear_x);
+    linear_y_ = apply_deadzone(raw_linear_y);
+    angular_z_ = apply_deadzone(raw_angular_z);
+    
+    // Check turbo button using semantic name
+    turbo_mode_ = get_button_value(button_turbo_);
+    
+    // Debug output (throttled)
+    RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                          "Joy input - Linear: [%.2f, %.2f], Angular: %.2f, Turbo: %s",
+                          linear_x_, linear_y_, angular_z_, turbo_mode_ ? "ON" : "OFF");
+}
+
+void GamepadController::publish_twist() {
+    geometry_msgs::msg::Twist twist_msg;
+    
+    // Calculate scales
+    double current_linear_scale = linear_scale_;
+    double current_angular_scale = angular_scale_;
+    
+    if (turbo_mode_) {
+        current_linear_scale *= turbo_multiplier_;
+        current_angular_scale *= turbo_multiplier_;
+    }
+    
+    // Set twist values
+    twist_msg.linear.x = linear_x_ * current_linear_scale;
+    twist_msg.linear.y = linear_y_ * current_linear_scale;
+    twist_msg.linear.z = 0.0;
+    
+    twist_msg.angular.x = 0.0;
+    twist_msg.angular.y = 0.0;
+    twist_msg.angular.z = angular_z_ * current_angular_scale;
+    
+    // Publish the message
+    cmd_vel_publisher_->publish(twist_msg);
+    
+    // Debug output for non-zero commands
+    if (std::abs(linear_x_) > 0.01 || std::abs(linear_y_) > 0.01 || std::abs(angular_z_) > 0.01) {
+        RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 500,
+                              "Publishing cmd_vel - Linear: [%.2f, %.2f, 0], Angular: [0, 0, %.2f]",
+                              twist_msg.linear.x, twist_msg.linear.y, twist_msg.angular.z);
+    }
+}
+
+} // namespace studica_control
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader
+RCLCPP_COMPONENTS_REGISTER_NODE(studica_control::GamepadController)

--- a/src/studica_control/src/manual_composition.cpp
+++ b/src/studica_control/src/manual_composition.cpp
@@ -9,6 +9,7 @@
 #include "studica_control/diff_drive_component.h"
 #include "studica_control/dio_component.h"
 #include "studica_control/encoder_component.h"
+#include "studica_control/gamepad_component.h"
 #include "studica_control/imu_component.h"
 #include "studica_control/mecanum_drive_component.h"
 #include "studica_control/servo_component.h"
@@ -30,6 +31,7 @@ public:
         this->declare_parameter<bool>("diff_drive_component.enabled", false);
         this->declare_parameter<bool>("dio.enabled", false);
         this->declare_parameter<bool>("encoder.enabled", false);
+        this->declare_parameter<bool>("gamepad.enabled", false);
         this->declare_parameter<bool>("imu.enabled", false);
         this->declare_parameter<bool>("mecanum_drive_component.enabled", false);
         this->declare_parameter<bool>("servo.enabled", false);
@@ -42,6 +44,7 @@ public:
         bool diff_drive_enabled = this->get_parameter("diff_drive_component.enabled").as_bool();
         bool dio_enabled = this->get_parameter("dio.enabled").as_bool();
         bool encoder_enabled = this->get_parameter("encoder.enabled").as_bool();
+        bool gamepad_enabled = this->get_parameter("gamepad.enabled").as_bool();
         bool imu_enabled = this->get_parameter("imu.enabled").as_bool();
         bool mecanum_drive_enabled = this->get_parameter("mecanum_drive_component.enabled").as_bool();
         bool servo_enabled = this->get_parameter("servo.enabled").as_bool();
@@ -79,6 +82,11 @@ public:
         if (encoder_enabled) {
             auto encoder_nodes = studica_control::Encoder::initialize(this, vmx_);
             component_nodes.insert(component_nodes.end(), encoder_nodes.begin(), encoder_nodes.end());
+        }
+
+        if (gamepad_enabled) {
+            auto gamepad_node = studica_control::GamepadController::initialize(this);
+            component_nodes.push_back(gamepad_node);
         }
 
         if (imu_enabled) {


### PR DESCRIPTION
game_controller_node:
This node utilizes SDL2's device mapping database to provide a consistent ordering of buttons and axes for game controllers, such as those from gaming consoles. Custom mappings can also be supplied.

As we are using a ps4 controller, using game_controller_node instead of joy_node gives us more semantic naming and default button mapping