### PR TITLE
Add Parsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,15 +602,19 @@ Topics are auto-generated from the sensor name. Using `"parsec"` as an example:
 
 | Topic | Type | Units / encoding | Best for |
 |---|---|---|---|
-| `/parsec/zones` | `studica_control/ParsecZoneMsg` | `fdist[]` in **mm** (`int16`) | Debug, logging, custom nodes — readable in `ros2 topic echo` |
-| `/parsec/depth` | `sensor_msgs/Image` (`16UC1`) | **mm per pixel**, 4×4 or 8×8 grid | RViz Image, OpenCV / cv_bridge |
+| `/parsec/zones` | `studica_control/ParsecZoneMsg` | `fdist[]` in **mm** (`int16`) | **`ros2 topic echo`** — human-readable mm per cell |
+| `/parsec/grid` | `sensor_msgs/Image` (`16UC1`) | mm encoded as **raw uint16 pixels** (4×4 or 8×8) | RViz / cv_bridge — **not** readable in `topic echo` (shows byte pairs) |
 | `/parsec/pointcloud` | `sensor_msgs/PointCloud2` (`xyz`) | **metres** (`float32` x, y, z) | RViz 3D, PCL, fusion with your own TF/odom |
 | `/parsec/min_range` | `sensor_msgs/Range` | **metres** — nearest valid zone | Simple obstacle / “closest hit” (always published) |
 
 Rate: `publish_rate_hz` (default 15 Hz).
 
 All three optional topics carry the **same underlying grid** — different ROS message packaging.
-Enable any combination in `publish_outputs`. If omitted or empty, **`depth`** is published by default.
+Enable any combination in `publish_outputs`. If omitted or empty, **`grid`** is published by default.
+
+> **Terminal debugging:** use **`/zones`** for mm you can read directly. **`/grid`** is a
+> `sensor_msgs/Image` — distances are mm per pixel, but `ros2 topic echo` only shows raw
+> bytes (decode with the snippet below, or use RViz / cv_bridge).
 
 **Zone values (`fdist`, mm):**
 
@@ -620,12 +624,12 @@ Enable any combination in `publish_outputs`. If omitted or empty, **`depth`** is
 | `-1` | Zone disabled (zone mask) |
 | `-2` | Invalid / no return |
 
-On `/depth`, disabled and invalid zones are published as pixel value `0`.
+On `/grid`, disabled and invalid zones are published as pixel value `0`.
 
 **Zone index layout** — row-major, top row first (index 0 = top-left). Grid is 4×4 or 8×8
 depending on firmware resolution (`RESOLUTION,16` or `RESOLUTION,64` on the device).
 
-**Decoding `/depth` (`16UC1`):**
+**Decoding `/grid` (`16UC1`):**
 
 Each pixel is a uint16 distance in mm, stored as **2 bytes little-endian** in `image.data`:
 
@@ -672,7 +676,7 @@ parsec:
     serial_port: /dev/ttyACM0 # USB only — run: ls /dev/ttyACM*
     frame_id: "parsec_link"
     publish_rate_hz: 15
-    publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
+    publish_outputs: ["zones", "grid", "pointcloud"]  # any of: zones, grid, pointcloud
 ```
 
 **Verify:**
@@ -691,12 +695,12 @@ ros2 service call /parsec/parsec_cmd studica_control/srv/SetData \
 
 **RViz:**
 
-- **Image:** add `/parsec/depth`, encoding `16UC1`. For a colour heatmap, convert to
+- **Image:** add `/parsec/grid`, encoding `16UC1`. For a colour heatmap, convert to
   another encoding in your node or use the point cloud view below.
 - **PointCloud2:** add `/parsec/pointcloud`, set **Fixed Frame** to `frame_id` (or your
   map/odom frame if you publish TF). Colour by **Axis → Z** for distance.
 
-> **Note:** `ros2 topic echo` on `/depth` shows raw bytes (e.g. `94, 1` = 350 mm). Use
+> **Note:** `ros2 topic echo` on `/grid` shows raw bytes (e.g. `94, 1` = 350 mm). Use
 > `/zones` for human-readable mm values, or decode the image as shown above.
 
 ---

--- a/README.md
+++ b/README.md
@@ -596,16 +596,16 @@ The **Parsec** is a Studica multi-zone time-of-flight sensor. It reports distanc
 for each cell in a **4×4 (16 zones)** or **8×8 (64 zones)** grid. Connect over **CAN**
 (default) or **USB** on the Pi (`/dev/ttyACM0`).
 
-Topics are auto-generated from the sensor name. Using `"front_tof"` as an example:
+Topics are auto-generated from the sensor name. Using `"parsec"` as an example:
 
 **Topics (publish) — optional outputs via `publish_outputs`:**
 
 | Topic | Type | Units / encoding | Best for |
 |---|---|---|---|
-| `/front_tof/zones` | `studica_control/ParsecZoneMsg` | `fdist[]` in **mm** (`int16`) | Debug, logging, custom nodes — readable in `ros2 topic echo` |
-| `/front_tof/depth` | `sensor_msgs/Image` (`16UC1`) | **mm per pixel**, 4×4 or 8×8 grid | RViz Image, OpenCV / cv_bridge |
-| `/front_tof/pointcloud` | `sensor_msgs/PointCloud2` (`xyz`) | **metres** (`float32` x, y, z) | RViz 3D, PCL, fusion with your own TF/odom |
-| `/front_tof/min_range` | `sensor_msgs/Range` | **metres** — nearest valid zone | Simple obstacle / “closest hit” (always published) |
+| `/parsec/zones` | `studica_control/ParsecZoneMsg` | `fdist[]` in **mm** (`int16`) | Debug, logging, custom nodes — readable in `ros2 topic echo` |
+| `/parsec/depth` | `sensor_msgs/Image` (`16UC1`) | **mm per pixel**, 4×4 or 8×8 grid | RViz Image, OpenCV / cv_bridge |
+| `/parsec/pointcloud` | `sensor_msgs/PointCloud2` (`xyz`) | **metres** (`float32` x, y, z) | RViz 3D, PCL, fusion with your own TF/odom |
+| `/parsec/min_range` | `sensor_msgs/Range` | **metres** — nearest valid zone | Simple obstacle / “closest hit” (always published) |
 
 Rate: `publish_rate_hz` (default 15 Hz).
 
@@ -652,7 +652,7 @@ img_mm = bridge.imgmsg_to_cv2(msg, desired_encoding='16UC1')  # numpy uint16, sh
 The driver does **not** publish TF. Set `frame_id` in `params.yaml` and provide your own
 `static_transform_publisher` or robot URDF if you need the cloud on the robot model.
 
-**Service:** `/front_tof/parsec_cmd` → `studica_control/SetData`
+**Service:** `/parsec/parsec_cmd` → `studica_control/SetData`
 
 | Command | Required fields | Description |
 |---|---|---|
@@ -665,12 +665,12 @@ The driver does **not** publish TF. Set `frame_id` in `params.yaml` and provide 
 ```yaml
 parsec:
   enabled: true
-  sensors: ["front_tof"]
-  front_tof:
+  sensors: ["parsec"]
+  parsec:
     transport: can            # "can" (VMX CAN bus) or "usb" (Pi serial)
     can_id: 5                 # CAN only — must match device CANID (0..63)
     serial_port: /dev/ttyACM0 # USB only — run: ls /dev/ttyACM*
-    frame_id: "parsec_front_link"
+    frame_id: "parsec_link"
     publish_rate_hz: 15
     publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
 ```
@@ -679,21 +679,21 @@ parsec:
 
 ```bash
 # Raw per-zone distances in mm (easiest to read in the terminal)
-ros2 topic echo /front_tof/zones --once
+ros2 topic echo /parsec/zones --once
 
 # Nearest hit in metres
-ros2 topic echo /front_tof/min_range --once
+ros2 topic echo /parsec/min_range --once
 
 # On-demand zone query (zone 0, mm)
-ros2 service call /front_tof/parsec_cmd studica_control/srv/SetData \
+ros2 service call /parsec/parsec_cmd studica_control/srv/SetData \
   "{params: 'get_zone_distance', initparams: {n_encoder: 0, speed: 0.0, int_value: 0, hold: false}}"
 ```
 
 **RViz:**
 
-- **Image:** add `/front_tof/depth`, encoding `16UC1`. For a colour heatmap, convert to
+- **Image:** add `/parsec/depth`, encoding `16UC1`. For a colour heatmap, convert to
   another encoding in your node or use the point cloud view below.
-- **PointCloud2:** add `/front_tof/pointcloud`, set **Fixed Frame** to `frame_id` (or your
+- **PointCloud2:** add `/parsec/pointcloud`, set **Fixed Frame** to `frame_id` (or your
   map/odom frame if you publish TF). Colour by **Axis → Z** for distance.
 
 > **Note:** `ros2 topic echo` on `/depth` shows raw bytes (e.g. `94, 1` = 350 mm). Use
@@ -1263,7 +1263,7 @@ node.create_subscription(Range, '/front/range', lambda msg: ..., 10)
 
 # Parsec multi-zone ToF — raw mm per cell (easiest to consume)
 from studica_control.msg import ParsecZoneMsg
-node.create_subscription(ParsecZoneMsg, '/front_tof/zones', lambda msg: ..., 10)
+node.create_subscription(ParsecZoneMsg, '/parsec/zones', lambda msg: ..., 10)
 
 # Cobra per-channel voltage
 node.create_subscription(Float32, '/line_sensor/ch_0', lambda msg: ..., 10)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A ROS2 hardware abstraction layer for the **Studica Robotics VMX** platform. Eac
   - [Servo](#servo)
   - [Ultrasonic](#ultrasonic--hc-sr04-range-sensor)
   - [Sharp](#sharp--gp2y-infrared-range-sensor)
+  - [Parsec](#parsec--multi-zone-tof-sensor)
   - [DIO](#dio--digital-inputoutput)
   - [Light Tower](#light-tower--5-output-led-indicator)
   - [Cobra](#cobra--reflectance-sensor-array)
@@ -45,6 +46,7 @@ A ROS2 hardware abstraction layer for the **Studica Robotics VMX** platform. Eac
 | **Servo** | Actuator | Standard (position), continuous (velocity), or linear |
 | **Ultrasonic** | Range Sensor | HC-SR04-style sonar, ~2 cm to 4 m |
 | **Sharp** | Range Sensor | GP2Y infrared rangefinder, ~10 cm to 80 cm |
+| **Parsec** | Range Sensor | Multi-zone ToF, 16 (4×4) or 64 (8×8) distance cells, CAN or USB |
 | **DIO** | Digital I/O | General-purpose digital input or output pin |
 | **Light Tower** | Indicator | 5-output LED tower — red, green, yellow, buzzer, continuous enable |
 | **Power** | System Monitor | Battery voltage, estimated state-of-charge, low-battery warnings — always on |
@@ -194,7 +196,7 @@ control_server:
 
 The following components support multiple instances by adding names to the `sensors` list and providing a config block for each name:
 
-`cobra`, `duty_cycle`, `dio`, `encoder`, `servo`, `sharp`, `titan`, `ultrasonic`
+`cobra`, `duty_cycle`, `dio`, `encoder`, `parsec`, `servo`, `sharp`, `titan`, `ultrasonic`
 
 ```yaml
 servo:
@@ -585,6 +587,117 @@ sharp:
     port: 22                  # VMX analog input channel
     frame_id: "side_ir_link"  # TF frame for the Range message header
 ```
+
+---
+
+### Parsec — Multi-Zone ToF Sensor
+
+The **Parsec** is a Studica multi-zone time-of-flight sensor. It reports distance
+for each cell in a **4×4 (16 zones)** or **8×8 (64 zones)** grid. Connect over **CAN**
+(default) or **USB** on the Pi (`/dev/ttyACM0`).
+
+Topics are auto-generated from the sensor name. Using `"front_tof"` as an example:
+
+**Topics (publish) — optional outputs via `publish_outputs`:**
+
+| Topic | Type | Units / encoding | Best for |
+|---|---|---|---|
+| `/front_tof/zones` | `studica_control/ParsecZoneMsg` | `fdist[]` in **mm** (`int16`) | Debug, logging, custom nodes — readable in `ros2 topic echo` |
+| `/front_tof/depth` | `sensor_msgs/Image` (`16UC1`) | **mm per pixel**, 4×4 or 8×8 grid | RViz Image, OpenCV / cv_bridge |
+| `/front_tof/pointcloud` | `sensor_msgs/PointCloud2` (`xyz`) | **metres** (`float32` x, y, z) | RViz 3D, PCL, fusion with your own TF/odom |
+| `/front_tof/min_range` | `sensor_msgs/Range` | **metres** — nearest valid zone | Simple obstacle / “closest hit” (always published) |
+
+Rate: `publish_rate_hz` (default 15 Hz).
+
+All three optional topics carry the **same underlying grid** — different ROS message packaging.
+Enable any combination in `publish_outputs`. If omitted or empty, **`depth`** is published by default.
+
+**Zone values (`fdist`, mm):**
+
+| Value | Meaning |
+|---|---|
+| `0` – `4000` | Valid distance in millimetres |
+| `-1` | Zone disabled (zone mask) |
+| `-2` | Invalid / no return |
+
+On `/depth`, disabled and invalid zones are published as pixel value `0`.
+
+**Zone index layout** — row-major, top row first (index 0 = top-left). Grid is 4×4 or 8×8
+depending on firmware resolution (`RESOLUTION,16` or `RESOLUTION,64` on the device).
+
+**Decoding `/depth` (`16UC1`):**
+
+Each pixel is a uint16 distance in mm, stored as **2 bytes little-endian** in `image.data`:
+
+```python
+# pixel index i (0 .. width*height-1)
+mm = msg.data[2 * i] + (msg.data[2 * i + 1] << 8)
+```
+
+With **cv_bridge** (recommended for image pipelines):
+
+```python
+from cv_bridge import CvBridge
+import numpy as np
+
+bridge = CvBridge()
+img_mm = bridge.imgmsg_to_cv2(msg, desired_encoding='16UC1')  # numpy uint16, shape (H, W)
+```
+
+**`/pointcloud` coordinates** — one point per valid zone, in `header.frame_id` (metres):
+
+- **z** — measured range for a cell (forward, in metres)
+- **x**, **y** — left/right and up/down offset from the sensor center, estimated from each cell’s position in the grid and the ~65° FOV
+
+The driver does **not** publish TF. Set `frame_id` in `params.yaml` and provide your own
+`static_transform_publisher` or robot URDF if you need the cloud on the robot model.
+
+**Service:** `/front_tof/parsec_cmd` → `studica_control/SetData`
+
+| Command | Required fields | Description |
+|---|---|---|
+| `get_config` | — | Device settings as a string in `response.message`. **USB:** full line from firmware (serial, resolution, CAN ID, zone mask, etc.). **CAN:** short summary only (`version=…, fdist_en=…, can_id=…`) — Classic CAN returns 8 bytes, not the full config |
+| `get_zone_distance` | `initparams.n_encoder` = zone index (0..zones−1) | Distance for one zone (**mm**) |
+| `get_min_distance` | — | Nearest valid zone distance (**mm**) |
+
+**params.yaml:**
+
+```yaml
+parsec:
+  enabled: true
+  sensors: ["front_tof"]
+  front_tof:
+    transport: can            # "can" (VMX CAN bus) or "usb" (Pi serial)
+    can_id: 5                 # CAN only — must match device CANID (0..63)
+    serial_port: /dev/ttyACM0 # USB only — run: ls /dev/ttyACM*
+    frame_id: "parsec_front_link"
+    publish_rate_hz: 15
+    publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
+```
+
+**Verify:**
+
+```bash
+# Raw per-zone distances in mm (easiest to read in the terminal)
+ros2 topic echo /front_tof/zones --once
+
+# Nearest hit in metres
+ros2 topic echo /front_tof/min_range --once
+
+# On-demand zone query (zone 0, mm)
+ros2 service call /front_tof/parsec_cmd studica_control/srv/SetData \
+  "{params: 'get_zone_distance', initparams: {n_encoder: 0, speed: 0.0, int_value: 0, hold: false}}"
+```
+
+**RViz:**
+
+- **Image:** add `/front_tof/depth`, encoding `16UC1`. For a colour heatmap, convert to
+  another encoding in your node or use the point cloud view below.
+- **PointCloud2:** add `/front_tof/pointcloud`, set **Fixed Frame** to `frame_id` (or your
+  map/odom frame if you publish TF). Colour by **Axis → Z** for distance.
+
+> **Note:** `ros2 topic echo` on `/depth` shows raw bytes (e.g. `94, 1` = 350 mm). Use
+> `/zones` for human-readable mm values, or decode the image as shown above.
 
 ---
 
@@ -1147,6 +1260,10 @@ node.create_subscription(Float64, '/titan0/m_2/angle', lambda msg: ..., 10)
 
 # Ultrasonic range (/<name>/range)
 node.create_subscription(Range, '/front/range', lambda msg: ..., 10)
+
+# Parsec multi-zone ToF — raw mm per cell (easiest to consume)
+from studica_control.msg import ParsecZoneMsg
+node.create_subscription(ParsecZoneMsg, '/front_tof/zones', lambda msg: ..., 10)
 
 # Cobra per-channel voltage
 node.create_subscription(Float32, '/line_sensor/ch_0', lambda msg: ..., 10)

--- a/drivers/examples/parsec_example/Makefile
+++ b/drivers/examples/parsec_example/Makefile
@@ -1,0 +1,26 @@
+CXX=g++
+CXXFLAGS=-I/usr/local/include/vmxpi -L/usr/local/lib/vmxpi -lvmxpi_hal_cpp -I/usr/local/include/studica_drivers -L/usr/local/lib/studica_drivers -lrt -lpthread -lstudica_drivers
+SOURCES=$(wildcard *.cpp)
+DEPS=$(SOURCES:.cpp=.d)
+BINS=$(SOURCES:.cpp=)
+# If using GCC version higher than 6, additionally link to libatomic.so
+GCCVERSION:=$(shell gcc -dumpversion | cut -f1 -d.)
+GCCVERSIONGE7:=$(shell expr $(GCCVERSION) \>= 7)
+ifeq "$(GCCVERSIONGE7)" "1"
+CXXFLAGS += -latomic
+endif
+all: $(patsubst %.cpp, %.out, $(SOURCES))
+
+%.out:  %.cpp Makefile
+	$(info GCC Version $(GCCVERSION))
+	$(CXX) $< -o $(@:.out=) $(CXXFLAGS)
+
+clean: $(patsubst %.cpp, %.clean, $(SOURCES))
+
+%.clean:
+	rm -f $(@:.clean=)
+
+run:
+	sudo ./$(BINS)
+
+-include $(DEPS)

--- a/drivers/examples/parsec_example/parsec_example.cpp
+++ b/drivers/examples/parsec_example/parsec_example.cpp
@@ -1,0 +1,218 @@
+/*
+ * parsec_example.cpp
+ *
+ * Standalone Parsec ToF demo (no ROS). Reads 100 frames and prints a zone grid.
+ *
+ * Build (on VMX / Pi, after drivers are installed):
+ *   cd ~/studica_ws/drivers/examples/parsec_example
+ *   make
+ *
+ * Run — CAN (default, needs sudo for VMX GPIO/CAN):
+ *   sudo ./parsec_example                    # default CAN ID 0 
+ *   sudo ./parsec_example can 5              # CAN ID 5
+ *
+ * Run — USB (Pi USB port; dialout group or sudo if permission denied):
+ *   ./parsec_example usb                     # default /dev/ttyACM0
+ *   ./parsec_example usb /dev/ttyACM1        # other port (ls /dev/ttyACM*)
+ *
+ */
+
+#include "parsec.hpp"
+#include "parsec_usb.hpp"
+
+#include "VMXPi.h"
+
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+enum class Mode { Usb, Can };
+
+struct Options {
+    Mode mode = Mode::Can;
+    std::string serial_port = "/dev/ttyACM0";
+    uint8_t can_id = 0;
+    int odr_hz = 15;
+    int iterations = 100;
+};
+
+bool is_valid_mm(int16_t d) { return d >= 1 && d <= 4000; }
+
+int16_t min_valid_mm(const int16_t* fdist, int count)
+{
+    int16_t min_d = INT16_MAX;
+    bool found = false;
+    for (int i = 0; i < count; ++i) {
+        if (is_valid_mm(fdist[i]) && fdist[i] < min_d) {
+            min_d = fdist[i];
+            found = true;
+        }
+    }
+    return found ? min_d : -1;
+}
+
+const char* zone_label(int16_t d)
+{
+    if (d == -1) {
+        return "off";
+    }
+    if (d == -2) {
+        return "invalid";
+    }
+    return nullptr;
+}
+
+void print_usage(const char* prog)
+{
+    printf("Usage:\n");
+    printf("  %s                         CAN on ID 0\n", prog);
+    printf("  %s can [can_id]            VMX CAN bus (default CAN ID 0)\n", prog);
+    printf("  %s usb [port]              USB serial (default port /dev/ttyACM0)\n", prog);
+    printf("\n");
+    printf("Environment:\n");
+    printf("  PARSEC_CAN_CHANNEL=1       Use VMX CAN1 instead of CAN0\n");
+}
+
+Options parse_args(int argc, char* argv[])
+{
+    Options opts;
+    if (argc <= 1) {
+        return opts;
+    }
+
+    const std::string mode = argv[1];
+    if (mode == "usb" || mode == "serial") {
+        opts.mode = Mode::Usb;
+        if (argc >= 3) {
+            opts.serial_port = argv[2];
+        }
+        return opts;
+    }
+
+    if (mode == "can") {
+        opts.mode = Mode::Can;
+        if (argc >= 3) {
+            opts.can_id = static_cast<uint8_t>(std::atoi(argv[2]));
+        }
+        return opts;
+    }
+
+    print_usage(argv[0]);
+    std::exit(1);
+}
+
+void print_grid(const int16_t* fdist, int zones)
+{
+    const int side = (zones == 64) ? 8 : 4;
+    for (int row = 0; row < side; ++row) {
+        printf("    ");
+        for (int col = 0; col < side; ++col) {
+            const int idx = row * side + col;
+            const int16_t d = fdist[idx];
+            const char* label = zone_label(d);
+            if (label) {
+                printf("%7s ", label);
+            } else {
+                printf("%4d mm ", d);
+            }
+        }
+        printf("\n");
+    }
+}
+
+void run_usb(const Options& opts)
+{
+    studica_driver::ParsecUsb parsec(opts.serial_port);
+    if (!parsec.IsOpen()) {
+        printf("Failed to open %s\n", opts.serial_port.c_str());
+        return;
+    }
+
+    if (!parsec.ConfigureStreaming(opts.odr_hz)) {
+        printf("Warning: streaming config failed on %s\n", opts.serial_port.c_str());
+    }
+
+    std::string config;
+    if (parsec.RequestConfig(&config)) {
+        printf("Parsec USB config: %s\n", config.c_str());
+    } else {
+        printf("Warning: GETCONFIG not received yet on %s\n", opts.serial_port.c_str());
+    }
+
+    std::vector<int16_t> fdist(studica_driver::ParsecUsb::kMaxZones, 0);
+    for (int i = 0; i < opts.iterations; ++i) {
+        uint8_t seq = 0;
+        uint8_t zones = 0;
+        const int n = parsec.ReadLatestFdist(&seq, &zones, fdist.data(),
+                                             static_cast<int>(fdist.size()));
+        if (n <= 0) {
+            printf("%3d | waiting for frame...\n", i);
+        } else {
+            const int16_t min_mm = min_valid_mm(fdist.data(), n);
+            const int center = n / 2;
+            printf("%3d | seq=%u zones=%u min=%d mm center[%d]=%d mm\n",
+                   i, seq, zones, min_mm, center, fdist[static_cast<size_t>(center)]);
+            print_grid(fdist.data(), n);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000 / opts.odr_hz));
+    }
+}
+
+void run_can(const Options& opts)
+{
+    std::shared_ptr<VMXPi> vmx = std::make_shared<VMXPi>(true, 50);
+    studica_driver::Parsec parsec(opts.can_id, vmx);
+    if (parsec.GetCanID() != opts.can_id) {
+        printf("Failed to init Parsec on CAN ID %u\n", opts.can_id);
+        return;
+    }
+
+    uint8_t config[64] = {0};
+    if (parsec.RequestConfig()) {
+        vmx->time.DelayMilliseconds(50);
+        if (parsec.GetConfigResponse(config, sizeof(config)) && config[0] != 0) {
+            printf("Parsec CAN config: version=%u fdist_en=%u can_id=%u\n",
+                   config[0], config[1], config[4]);
+        }
+    }
+
+    std::vector<int16_t> fdist(studica_driver::ParsecUsb::kMaxZones, 0);
+    for (int i = 0; i < opts.iterations; ++i) {
+        uint8_t seq = 0;
+        uint8_t zones = 0;
+        const int n = parsec.ReadDataStreamCAN2(&seq, &zones, fdist.data(),
+                                                static_cast<int>(fdist.size()));
+        if (n <= 0) {
+            printf("%3d | waiting for frame...\n", i);
+        } else {
+            const int16_t min_mm = min_valid_mm(fdist.data(), n);
+            const int center = n / 2;
+            printf("%3d | seq=%u zones=%u min=%d mm center[%d]=%d mm\n",
+                   i, seq, zones, min_mm, center, fdist[static_cast<size_t>(center)]);
+            print_grid(fdist.data(), n);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000 / opts.odr_hz));
+    }
+}
+
+}  // namespace
+
+int main(int argc, char* argv[])
+{
+    const Options opts = parse_args(argc, argv);
+    if (opts.mode == Mode::Usb) {
+        printf("Parsec USB example on %s at %d Hz\n", opts.serial_port.c_str(), opts.odr_hz);
+        run_usb(opts);
+    } else {
+        printf("Parsec CAN example on ID %u at %d Hz\n", opts.can_id, opts.odr_hz);
+        run_can(opts);
+    }
+    return 0;
+}

--- a/drivers/parsec.cpp
+++ b/drivers/parsec.cpp
@@ -1,0 +1,275 @@
+#include "parsec.hpp"
+#include "VMXPi.h"
+#include <cstdlib>
+#include <cstring>
+#include <stdio.h>
+#include <array>
+#include <map>
+#include <vector>
+
+namespace studica_driver {
+
+static unsigned s_canChannel = 0;
+
+unsigned Parsec::GetCANChannel() { return s_canChannel; }
+
+Parsec::Parsec(uint8_t canID, std::shared_ptr<VMXPi> vmx)
+    : vmx_(vmx), canID_(canID)
+{
+    const char* chEnv = std::getenv("PARSEC_CAN_CHANNEL");
+    s_canChannel = (chEnv && chEnv[0] == '1' && chEnv[1] == '\0') ? 1u : 0u;
+    if (canID_ > 63)
+    {
+        printf("Parsec CAN ID %u is out of range (0..63).\n", canID_);
+        fflush(stdout);
+        return;
+    }
+
+    VMXErrorCode vmxerr;
+    if (!vmx_ || !vmx_->IsOpen())
+    {
+        printf("Parsec: VMXPi not open.\n");
+        fflush(stdout);
+        return;
+    }
+
+    /* Filter: only accept Parsec IDs 0x0609xxxx (ignore Titan 0x020C0xxx and others) */
+    if (!vmx_->can.OpenReceiveStream(canrxhandle_, PARSEC_BASE, 0x1FFF0000u, 100, &vmxerr))
+        printf("Parsec: Error opening CAN RX Stream.\n");
+    else
+    {
+        printf("Parsec: Opened CAN RX Stream (filter 0x0609xxxx), handle %d\n", canrxhandle_);
+        if (vmx_->can.EnableReceiveStreamBlackboard(canrxhandle_, true, &vmxerr))
+            printf("Parsec: Blackboard enabled.\n");
+        else
+            printf("Parsec: Error enabling Blackboard.\n");
+    }
+
+    if (!vmx_->can.FlushRxFIFO(&vmxerr))
+        printf("Parsec: Error flushing CAN RX FIFO.\n");
+    if (!vmx_->can.FlushTxFIFO(&vmxerr))
+        printf("Parsec: Error flushing CAN TX FIFO.\n");
+    if (!vmx_->can.SetMode(VMXCAN::VMXCAN_NORMAL, &vmxerr))
+        printf("Parsec: Error setting CAN mode to Normal.\n");
+    else
+        printf("Parsec: CAN mode Normal.\n");
+
+    vmx_->time.DelayMilliseconds(20);
+    printf("Parsec driver started (CAN ID %u, VMX CAN channel %u).\n", canID_, s_canChannel);
+    if (s_canChannel == 0)
+        printf("  (Use: sudo PARSEC_CAN_CHANNEL=1 ./parsec_example for VMX CAN1)\n");
+    fflush(stdout);
+}
+
+Parsec::~Parsec()
+{
+    /* Do not close the receive stream here. Explicit CloseReceiveStream leaves VMX
+     * in a state where the next run cannot receive CAN (second run finds no device).
+     * Rely on process exit so the next run can open a fresh stream. */
+}
+
+uint32_t Parsec::GetAddress(uint32_t index) const
+{
+    return PARSEC_BASE + canID_ + (PARSEC_OFFSET * index);
+}
+
+uint32_t Parsec::GetAddressForCanID(uint8_t canID, uint32_t index)
+{
+    return PARSEC_BASE + canID + (PARSEC_OFFSET * index);
+}
+
+bool Parsec::Write(uint32_t address, const uint8_t* data, size_t len, int32_t periodMS)
+{
+    if (!vmx_ || !vmx_->IsOpen() || !data) return false;
+    if (len > 8) len = 8;  // VMX classic CAN typically 8 bytes
+    VMXCANMessage msg;
+    msg.dataSize = static_cast<int>(len);
+    msg.setData(const_cast<uint8_t*>(data), static_cast<int>(len));
+    msg.messageID = address;
+    VMXErrorCode vmxerr;
+    return vmx_->can.SendMessage(msg, periodMS, &vmxerr);
+}
+
+void Parsec::PullCANData()
+{
+    /* VMXPi(true, rate_hz) already calls RetrieveAllCANData on its IO thread.
+     * A manual call here races that thread and spams "Empty Packet entry" in VMXCAN.cpp. */
+}
+
+int Parsec::Read(uint32_t address, uint8_t* data, size_t maxLen)
+{
+    if (!vmx_ || !data || maxLen == 0) return 0;
+    return ReadCached(address, data, maxLen);
+}
+
+int Parsec::ReadCached(uint32_t address, uint8_t* data, size_t maxLen)
+{
+    if (!vmx_ || !data || maxLen == 0) return 0;
+    VMXCANTimestampedMessage blackboard_msg;
+    uint64_t sys_timestamp;
+    bool already_retrieved;
+    VMXErrorCode vmxerr;
+    /* Try plain ID first, then with extended-ID bit (0x80000000) in case VMX keys by that */
+    uint32_t key = address;
+    if (!vmx_->can.GetBlackboardEntry(canrxhandle_, key, blackboard_msg, sys_timestamp, already_retrieved, &vmxerr))
+    {
+        key = address | 0x80000000u;
+        if (!vmx_->can.GetBlackboardEntry(canrxhandle_, key, blackboard_msg, sys_timestamp, already_retrieved, &vmxerr))
+            return 0;
+    }
+    int n = blackboard_msg.dataSize;
+    if (n <= 0 || n > 64) n = 8;
+    size_t copyLen = (maxLen < (size_t)n) ? maxLen : (size_t)n;
+    std::memcpy(data, blackboard_msg.data, copyLen);
+    return (int)copyLen;
+}
+
+void Parsec::DumpReceiveStream(unsigned maxMessages)
+{
+    if (!vmx_ || maxMessages == 0) return;
+    std::vector<VMXCANTimestampedMessage> msgs(maxMessages);
+    uint32_t numRead = 0;
+    VMXErrorCode vmxerr;
+    if (!vmx_->can.ReadReceiveStream(canrxhandle_, msgs.data(), maxMessages, numRead, &vmxerr) || numRead == 0) {
+        printf("  (no CAN frames in stream)\n");
+        return;
+    }
+    printf("  Raw CAN stream: %u frame(s)\n", numRead);
+    for (uint32_t i = 0; i < numRead; i++) {
+        uint32_t id = msgs[i].messageID;
+        int n = msgs[i].dataSize;
+        if (n <= 0 || n > 64) n = 8;
+        bool ext = true;
+        if (id & 0x80000000u) { ext = false; id &= 0x7FFFFFFFu; }
+        printf("    [%u] ID=0x%08X (%s) len=%d  data:", i, id, ext ? "ext" : "std", n);
+        for (int j = 0; j < n && j < 8; j++) printf(" %02X", msgs[i].data[j]);
+        if (n > 8) printf(" ...");
+        printf("\n");
+    }
+}
+
+bool Parsec::RequestConfig()
+{
+    uint8_t req[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    return Write(GetAddress(PARSEC_GETCONFIG), req, 8, 0);
+}
+
+bool Parsec::GetConfigResponse(uint8_t* configOut, unsigned maxLen)
+{
+    if (!configOut || maxLen < 8) return false;
+    return Read(GetAddress(PARSEC_CMD_RESP), configOut, maxLen) >= 8;
+}
+
+int Parsec::ReadDataChunk(uint32_t dataIndex, uint8_t* dataOut, unsigned maxLen)
+{
+    if (dataIndex > 3 || !dataOut || maxLen < 2) return 0;
+    uint32_t id = GetAddress(PARSEC_DATA0 + dataIndex);
+    int n = Read(id, dataOut, maxLen);
+    if (n < 2) return 0;
+    // Payload: [0]=seq, [1]=zones or block_idx (CAN2), [2..] = int16 LE per zone. Classic CAN = 8 bytes; FD can send up to 34 per chunk.
+    return n;
+}
+
+int Parsec::ReadDataStreamCAN2(uint8_t* seqOut, uint8_t* zonesOut, int16_t* fdist, int maxZones)
+{
+    if (!vmx_ || !fdist || maxZones <= 0 || maxZones > 64) return -1;
+
+    const uint32_t data0Id = GetAddress(PARSEC_DATA0);
+    std::map<uint8_t, std::map<uint8_t, std::array<int16_t, 3>>> bySeq;
+    auto rd16 = [](const uint8_t* p) {
+        return (int16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+    };
+
+    /* Drain receive stream (VMX IO thread fills it). Multiple rounds collect burst DATA0
+     * frames (64 zones = 22 frames). Do not call RetrieveAllCANData here — that races the IO thread. */
+    std::vector<VMXCANTimestampedMessage> msgs(128);
+    auto drainData0Frames = [&]() {
+        for (;;) {
+            uint32_t numRead = 0;
+            VMXErrorCode vmxerr;
+            if (!vmx_->can.ReadReceiveStream(canrxhandle_, msgs.data(), static_cast<unsigned>(msgs.size()),
+                                             numRead, &vmxerr) || numRead == 0) {
+                break;
+            }
+            for (uint32_t i = 0; i < numRead; i++) {
+                uint32_t id = msgs[i].messageID & 0x7FFFFFFFu;
+                if (id != data0Id) continue;
+                int n = msgs[i].dataSize;
+                if (n < 8) continue;
+                const uint8_t* d = msgs[i].data;
+                uint8_t seq = d[0], blk = d[1];
+                bySeq[seq][blk] = {{ rd16(d + 2), rd16(d + 4), rd16(d + 6) }};
+            }
+        }
+    };
+    for (int round = 0; round < 3; round++) {
+        drainData0Frames();
+        if (round < 2) vmx_->time.DelayMilliseconds(12);
+    }
+
+    if (bySeq.empty()) return 0;
+
+    // Choose seq with most blocks (prefer one that has block 0)
+    uint8_t bestSeq = 0;
+    size_t bestCount = 0;
+    for (const auto& kv : bySeq) {
+        size_t cnt = kv.second.size();
+        if (cnt > bestCount || (cnt == bestCount && kv.second.count(0))) {
+            bestCount = cnt;
+            bestSeq = kv.first;
+        }
+    }
+    const auto& blocks = bySeq[bestSeq];
+    if (blocks.empty()) return 0;
+
+    unsigned int maxBlk = 0;
+    for (const auto& kv : blocks)
+        if (kv.first > maxBlk) maxBlk = kv.first;
+
+    const int blocksNeeded = (maxZones + 2) / 3;
+    int zonesFilled = 0;
+    for (int b = 0; b < blocksNeeded && (b * 3) < maxZones; b++) {
+        auto it = blocks.find(static_cast<uint8_t>(b));
+        const bool have = (it != blocks.end());
+        for (int i = 0; i < 3; i++) {
+            int zi = b * 3 + i;
+            if (zi >= maxZones) break;
+            fdist[zi] = have ? it->second[i] : -1;
+            zonesFilled = zi + 1;
+        }
+    }
+    /* Effective zone count = last index with non-padding (-1) + 1, so 16 zones shows 16 not 18 */
+    int effectiveZones = 0;
+    for (int i = 0; i < zonesFilled; i++)
+        if (fdist[i] != -1) effectiveZones = i + 1;
+
+    if (seqOut) *seqOut = bestSeq;
+    if (zonesOut) *zonesOut = (uint8_t)(effectiveZones > 0 ? effectiveZones : zonesFilled);
+    return zonesFilled;
+}
+
+void Parsec::ParseConfigApiIds(const uint8_t* config, uint32_t* meta, uint32_t* data0, uint32_t* data1,
+                               uint32_t* data2, uint32_t* data3, uint32_t* getconfig, uint32_t* cmdResp)
+{
+    auto rd32 = [](const uint8_t* p) {
+        return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    };
+    if (meta)     *meta     = rd32(config + 8);
+    if (data0)    *data0    = rd32(config + 12);
+    if (data1)    *data1    = rd32(config + 16);
+    if (data2)    *data2    = rd32(config + 20);
+    if (data3)    *data3    = rd32(config + 24);
+    if (getconfig)*getconfig= rd32(config + 28);
+    if (cmdResp)  *cmdResp  = rd32(config + 32);
+}
+
+uint64_t Parsec::ParseConfigZoneMask(const uint8_t* config)
+{
+    auto rd64 = [](const uint8_t* p) {
+        return (uint64_t)p[0] | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) | ((uint64_t)p[3] << 24)
+             | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) | ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
+    };
+    return rd64(config + 36);
+}
+
+} // namespace studica_driver

--- a/drivers/parsec.hpp
+++ b/drivers/parsec.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+struct VMXPi;
+
+/**
+ * Host-side driver for Parsec ToF sensor over CAN.
+ * CAN ID layout matches firmware: address = (DEVICE_TYPE + MANID + canID) + OFFSET * index.
+ * Use GetAddress(INDEX) to get the CAN ID for a given API index.
+ */
+namespace studica_driver {
+
+// Match Parsec firmware: fdcan_cmd.h (OFFSET*index: 0x40*16=0x400, so GETCONFIG id0=0x06090400)
+#define PARSEC_DEVICE_TYPE  0x06000000u
+#define PARSEC_MANID        0x00090000u
+#define PARSEC_OFFSET       0x40u
+#define PARSEC_BASE         (PARSEC_DEVICE_TYPE + PARSEC_MANID)  // 0x06090000
+
+// API indices (GetAddress(index)); GETCONFIG=16 => BASE+0x400+canID e.g. 0x06090400 for canID 0
+#define PARSEC_META         0
+#define PARSEC_DATA0        1
+#define PARSEC_DATA1        2
+#define PARSEC_DATA2        3
+#define PARSEC_DATA3        4
+#define PARSEC_GETCONFIG    16
+#define PARSEC_CMD_RESP     17
+
+// GETCONFIG response layout:
+// - CAN FD: CMD_RESP can be up to 44 bytes (full config with API IDs and zone mask).
+// - CAN2 (Classic): CMD_RESP is 8 bytes only: [0]=version, [1]=fdist_en, [2]=can_fd_enabled,
+//   [3]=can_brs_status, [4]=CAN_ID, [5..7]=reserved. Use fixed PARSEC_* indices for addresses.
+// Full 44-byte layout (when len>=44): [8..11] META, [12..15] DATA0, ... [32..35] CMD_RESP, [36..43] zone mask.
+
+// DATA frames:
+// - CAN FD: DATA0..DATA3, each [0]=seq, [1]=zones, [2..]=int16 LE (16 zones per chunk).
+// - CAN2: only DATA0 is used; multiple 8-byte frames: [0]=seq, [1]=block_idx, [2..7]=3×int16 LE.
+//   Reassemble with ReadDataStreamCAN2().
+
+class Parsec {
+public:
+    /**
+     * @param canID Device CAN ID (0..63), must match device's CANID setting.
+     * @param vmx    VMXPi instance (e.g. std::make_shared<VMXPi>(true, 50)).
+     */
+    Parsec(uint8_t canID, std::shared_ptr<VMXPi> vmx);
+    ~Parsec();
+
+    /** CAN address for this device: (PARSEC_BASE + canID_) + PARSEC_OFFSET * index */
+    uint32_t GetAddress(uint32_t index) const;
+
+    /** CAN address for any canID (for scanning). address = PARSEC_BASE + canID + PARSEC_OFFSET * index */
+    static uint32_t GetAddressForCanID(uint8_t canID, uint32_t index);
+
+    /** Send GETCONFIG request; response arrives on CMD_RESP. Returns true if send ok. */
+    bool RequestConfig();
+    /**
+     * Read GETCONFIG response from blackboard (CMD_RESP).
+     * configOut at least 8 bytes (classic CAN); 44 bytes for full config (CAN FD). Returns true if entry found.
+     */
+    bool GetConfigResponse(uint8_t* configOut, unsigned maxLen = 64);
+
+    /** Read one DATA frame (DATA0..DATA3) from blackboard. dataOut at least 64 bytes. Returns payload length or 0. */
+    int ReadDataChunk(uint32_t dataIndex, uint8_t* dataOut, unsigned maxLen = 64);
+
+    /**
+     * CAN2 only: reassemble distance data from DATA0 stream (multiple 8-byte frames with block_idx).
+     * Drains the VMX receive stream (IO thread fills it). fdist[] filled with int16 LE; -1 = invalid/missing.
+     * @param seqOut    optional; set to frame sequence number
+     * @param zonesOut  optional; set to number of zones (from received blocks)
+     * @param fdist     output array, at least maxZones elements
+     * @param maxZones  typically 16 or 64
+     * @return number of zones filled (0 if no DATA0 frames), or -1 on error
+     */
+    int ReadDataStreamCAN2(uint8_t* seqOut, uint8_t* zonesOut, int16_t* fdist, int maxZones = 64);
+
+    /** Parse CAN ID from config response bytes [8..35] (7 x uint32 LE). */
+    static void ParseConfigApiIds(const uint8_t* config, uint32_t* meta, uint32_t* data0, uint32_t* data1,
+                                  uint32_t* data2, uint32_t* data3, uint32_t* getconfig, uint32_t* cmdResp);
+    /** Parse zone mask from config bytes [36..43] (uint64 LE). */
+    static uint64_t ParseConfigZoneMask(const uint8_t* config);
+
+    uint8_t GetCanID() const { return canID_; }
+
+    /** Raw Write: send one CAN frame to given address (8 bytes for classic). */
+    bool Write(uint32_t address, const uint8_t* data, size_t len, int32_t periodMS = 0);
+    /** No-op when VMXPi uses periodic IO (RetrieveAllCANData runs on the VMX thread). */
+    void PullCANData();
+    /** Read latest frame for address from blackboard. Returns bytes copied, 0 on failure. */
+    int Read(uint32_t address, uint8_t* data, size_t maxLen);
+    /** Same as Read(); kept for callers that previously pulled before a batch read. */
+    int ReadCached(uint32_t address, uint8_t* data, size_t maxLen);
+
+    /** Diagnostic: read up to maxMessages from receive stream and print ID + data. Use when no device found. */
+    void DumpReceiveStream(unsigned maxMessages = 32);
+
+    /** VMX CAN channel (0 or 1). Set env PARSEC_CAN_CHANNEL=1 to use CAN1. */
+    static unsigned GetCANChannel();
+
+private:
+    std::shared_ptr<VMXPi> vmx_;
+    uint8_t canID_;
+    unsigned int canrxhandle_{0};  // VMXCANReceiveStreamHandle
+};
+
+} // namespace studica_driver

--- a/drivers/parsec_usb.cpp
+++ b/drivers/parsec_usb.cpp
@@ -1,0 +1,366 @@
+#include "parsec_usb.hpp"
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <fcntl.h>
+#include <poll.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace studica_driver {
+
+namespace {
+
+speed_t baudToConstant(int baud)
+{
+    switch (baud) {
+        case 9600: return B9600;
+        case 19200: return B19200;
+        case 38400: return B38400;
+        case 57600: return B57600;
+        case 115200: return B115200;
+        case 230400: return B230400;
+        case 460800: return B460800;
+        case 921600: return B921600;
+        default: return B115200;
+    }
+}
+
+}  // namespace
+
+ParsecUsb::ParsecUsb(const std::string& port, int baud)
+    : port_(port)
+{
+    fd_ = open(port.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd_ < 0) {
+        return;
+    }
+
+    termios tty{};
+    if (tcgetattr(fd_, &tty) != 0) {
+        close(fd_);
+        fd_ = -1;
+        return;
+    }
+
+    cfmakeraw(&tty);
+    cfsetispeed(&tty, baudToConstant(baud));
+    cfsetospeed(&tty, baudToConstant(baud));
+    tty.c_cflag |= (CLOCAL | CREAD);
+    tty.c_cflag &= ~CSIZE;
+    tty.c_cflag |= CS8;
+    tty.c_cflag &= ~PARENB;
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag &= ~CRTSCTS;
+    tty.c_iflag &= ~(IXON | IXOFF | IXANY);
+    tty.c_cc[VMIN] = 0;
+    tty.c_cc[VTIME] = 0;
+
+    if (tcsetattr(fd_, TCSANOW, &tty) != 0) {
+        close(fd_);
+        fd_ = -1;
+        return;
+    }
+}
+
+ParsecUsb::~ParsecUsb()
+{
+    stopReader();
+    if (fd_ >= 0) {
+        close(fd_);
+        fd_ = -1;
+    }
+}
+
+void ParsecUsb::startReader()
+{
+    if (fd_ < 0 || running_) {
+        return;
+    }
+    running_ = true;
+    reader_ = std::thread(&ParsecUsb::readerLoop, this);
+}
+
+void ParsecUsb::stopReader()
+{
+    running_ = false;
+    if (reader_.joinable()) {
+        reader_.join();
+    }
+}
+
+bool ParsecUsb::SendCommand(const std::string& cmd)
+{
+    if (fd_ < 0) {
+        return false;
+    }
+    std::string line = cmd;
+    if (line.empty() || line.back() != '\n') {
+        line += "\r\n";
+    }
+    const char* data = line.c_str();
+    size_t left = line.size();
+    while (left > 0) {
+        const ssize_t n = write(fd_, data, left);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+            return false;
+        }
+        data += n;
+        left -= static_cast<size_t>(n);
+    }
+    return true;
+}
+
+bool ParsecUsb::ConfigureStreaming(int odr_hz)
+{
+    if (fd_ < 0) {
+        return false;
+    }
+    if (!SendCommand("GETCONFIG")) {
+        return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    std::string junk;
+    while (readLine(&junk, 50)) {
+        // drain GETCONFIG text response
+    }
+
+    if (!SendCommand("VERBOSE,0")) {
+        return false;
+    }
+    if (!SendCommand("DATAFORMAT,BIN")) {
+        return false;
+    }
+    if (odr_hz > 0) {
+        SendCommand("ODR," + std::to_string(odr_hz));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    while (readLine(&junk, 20)) {
+    }
+    startReader();
+    return true;
+}
+
+bool ParsecUsb::RequestConfig(std::string* response_out)
+{
+    if (fd_ < 0 || response_out == nullptr) {
+        return false;
+    }
+    response_out->clear();
+
+    const bool was_running = running_;
+    if (was_running) {
+        stopReader();
+    }
+
+    const bool ok = SendCommand("GETCONFIG") && readLine(response_out, 500);
+
+    if (was_running) {
+        startReader();
+    }
+    return ok;
+}
+
+int ParsecUsb::ReadLatestFdist(uint8_t* seq_out, uint8_t* zones_out, int16_t* fdist, int max_zones)
+{
+    if (fdist == nullptr || max_zones <= 0) {
+        return 0;
+    }
+
+    std::lock_guard<std::mutex> lock(frame_mutex_);
+    if (!has_frame_) {
+        return 0;
+    }
+
+    const int n = (latest_zones_ < static_cast<uint8_t>(max_zones)) ? latest_zones_ : max_zones;
+    for (int i = 0; i < n; ++i) {
+        fdist[i] = latest_fdist_[static_cast<size_t>(i)];
+    }
+    if (seq_out) {
+        *seq_out = latest_seq_;
+    }
+    if (zones_out) {
+        *zones_out = latest_zones_;
+    }
+    return n;
+}
+
+void ParsecUsb::readerLoop()
+{
+    uint8_t chunk[256];
+    while (running_) {
+        if (fd_ < 0) {
+            break;
+        }
+
+        pollfd pfd{};
+        pfd.fd = fd_;
+        pfd.events = POLLIN;
+        const int pr = poll(&pfd, 1, 50);
+        if (pr < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        if (pr == 0) {
+            continue;
+        }
+
+        const ssize_t n = read(fd_, chunk, sizeof(chunk));
+        if (n < 0) {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+            break;
+        }
+        if (n == 0) {
+            continue;
+        }
+
+        rx_buf_.insert(rx_buf_.end(), chunk, chunk + n);
+        if (rx_buf_.size() > 8192) {
+            rx_buf_.erase(rx_buf_.begin(), rx_buf_.end() - 4096);
+        }
+        consumeRxBuffer();
+    }
+}
+
+void ParsecUsb::consumeRxBuffer()
+{
+    while (rx_buf_.size() >= sizeof(FrameHdr)) {
+        size_t start = 0;
+        bool found = false;
+        for (size_t i = 0; i + 1 < rx_buf_.size(); ++i) {
+            if (rx_buf_[i] == 0xA5 && rx_buf_[i + 1] == 0x5A) {
+                start = i;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            if (rx_buf_.size() > 1) {
+                rx_buf_.erase(rx_buf_.begin(), rx_buf_.end() - 1);
+            }
+            return;
+        }
+        if (start > 0) {
+            rx_buf_.erase(rx_buf_.begin(), rx_buf_.begin() + static_cast<std::ptrdiff_t>(start));
+        }
+        if (rx_buf_.size() < sizeof(FrameHdr)) {
+            return;
+        }
+
+        size_t frame_len = 0;
+        if (!tryParseFrame(0, &frame_len)) {
+            return;
+        }
+        rx_buf_.erase(rx_buf_.begin(), rx_buf_.begin() + static_cast<std::ptrdiff_t>(frame_len));
+    }
+}
+
+bool ParsecUsb::tryParseFrame(size_t offset, size_t* frame_len_out)
+{
+    if (rx_buf_.size() < offset + sizeof(FrameHdr)) {
+        return false;
+    }
+
+    FrameHdr hdr{};
+    std::memcpy(&hdr, rx_buf_.data() + offset, sizeof(hdr));
+    if (hdr.magic != kFrameMagic) {
+        rx_buf_.erase(rx_buf_.begin());
+        return false;
+    }
+
+    const size_t total = 4u + static_cast<size_t>(hdr.length);
+    if (rx_buf_.size() < offset + total) {
+        return false;
+    }
+
+    if (hdr.type != 1) {
+        *frame_len_out = total;
+        return true;
+    }
+
+    const uint8_t* payload = rx_buf_.data() + offset + sizeof(FrameHdr);
+    const size_t payload_len = total - sizeof(FrameHdr);
+
+    if ((hdr.flags & 0x01) == 0) {
+        *frame_len_out = total;
+        return true;
+    }
+
+    const size_t fdist_bytes = static_cast<size_t>(hdr.zones) * sizeof(int16_t);
+    if (payload_len < fdist_bytes) {
+        *frame_len_out = total;
+        return true;
+    }
+
+    std::lock_guard<std::mutex> lock(frame_mutex_);
+    latest_seq_ = hdr.streamcount;
+    latest_zones_ = hdr.zones;
+    for (uint8_t i = 0; i < hdr.zones && i < kMaxZones; ++i) {
+        int16_t v = 0;
+        std::memcpy(&v, payload + static_cast<size_t>(i) * sizeof(int16_t), sizeof(v));
+        latest_fdist_[i] = v;
+    }
+    for (uint8_t i = hdr.zones; i < kMaxZones; ++i) {
+        latest_fdist_[i] = -1;
+    }
+    has_frame_ = true;
+
+    *frame_len_out = total;
+    return true;
+}
+
+bool ParsecUsb::readLine(std::string* line_out, int timeout_ms)
+{
+    if (fd_ < 0 || line_out == nullptr) {
+        return false;
+    }
+
+    line_out->clear();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+    while (std::chrono::steady_clock::now() < deadline) {
+        pollfd pfd{};
+        pfd.fd = fd_;
+        pfd.events = POLLIN;
+        const int wait_ms = 20;
+        const int pr = poll(&pfd, 1, wait_ms);
+        if (pr <= 0) {
+            if (!line_out->empty()) {
+                break;
+            }
+            continue;
+        }
+
+        char c = 0;
+        const ssize_t n = read(fd_, &c, 1);
+        if (n <= 0) {
+            continue;
+        }
+        if (c == '\r') {
+            continue;
+        }
+        if (c == '\n') {
+            if (!line_out->empty()) {
+                return true;
+            }
+            continue;
+        }
+        line_out->push_back(c);
+    }
+
+    return !line_out->empty();
+}
+
+}  // namespace studica_driver

--- a/drivers/parsec_usb.hpp
+++ b/drivers/parsec_usb.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace studica_driver {
+
+/**
+ * Host driver for Parsec over USB CDC serial (Pi /dev/ttyACM0).
+ * Parses firmware binary distance frames (magic 0x5AA5, type=1, fdist[]).
+ */
+class ParsecUsb {
+public:
+    static constexpr int kMaxZones = 64;
+
+    /** @param port e.g. /dev/ttyACM0 on Linux */
+    explicit ParsecUsb(const std::string& port, int baud = 115200);
+    ~ParsecUsb();
+
+    ParsecUsb(const ParsecUsb&) = delete;
+    ParsecUsb& operator=(const ParsecUsb&) = delete;
+
+    bool IsOpen() const { return fd_ >= 0; }
+
+    /** Send a text command (GETCONFIG, VERBOSE,0, …). Appends \\r\\n. */
+    bool SendCommand(const std::string& cmd);
+
+    /** Wake device, set binary fdist-only output. Call once after open. */
+    bool ConfigureStreaming(int odr_hz);
+
+    /** Send GETCONFIG and collect the text response line. */
+    bool RequestConfig(std::string* response_out);
+
+    /**
+     * Copy the latest parsed frame.
+     * @return zone count (16 or 64), or 0 if no frame yet.
+     */
+    int ReadLatestFdist(uint8_t* seq_out, uint8_t* zones_out, int16_t* fdist, int max_zones);
+
+private:
+    static constexpr uint16_t kFrameMagic = 0x5AA5;
+
+#pragma pack(push, 1)
+    struct FrameHdr {
+        uint16_t magic;
+        uint16_t length;
+        uint8_t type;
+        uint8_t streamcount;
+        uint8_t zones;
+        uint8_t flags;
+    };
+#pragma pack(pop)
+
+    int fd_{-1};
+    std::string port_;
+    std::thread reader_;
+    std::atomic<bool> running_{false};
+
+    std::mutex frame_mutex_;
+    std::array<int16_t, kMaxZones> latest_fdist_{};
+    uint8_t latest_seq_{0};
+    uint8_t latest_zones_{0};
+    bool has_frame_{false};
+
+    std::vector<uint8_t> rx_buf_;
+
+    void readerLoop();
+    void startReader();
+    void stopReader();
+    void consumeRxBuffer();
+    bool tryParseFrame(size_t offset, size_t* frame_len_out);
+    bool readLine(std::string* line_out, int timeout_ms);
+};
+
+}  // namespace studica_driver

--- a/src/studica_control/CMakeLists.txt
+++ b/src/studica_control/CMakeLists.txt
@@ -229,6 +229,7 @@ set(cpp_example_targets
   cobra_example
   gamepad_example
   light_tower_example
+  parsec_example
 )
 
 foreach(target ${cpp_example_targets})
@@ -254,6 +255,7 @@ set(python_example_scripts
   src/components/examples/python/cobra_example.py
   src/components/examples/python/gamepad_example.py
   src/components/examples/python/light_tower_example.py
+  src/components/examples/python/parsec_example.py
 )
 
 install(PROGRAMS ${python_example_scripts}

--- a/src/studica_control/CMakeLists.txt
+++ b/src/studica_control/CMakeLists.txt
@@ -22,8 +22,10 @@ rosidl_generate_interfaces(${PROJECT_NAME} # <- SRV files (srv, msg, action)
   "msg/DutyCycleEncoderMsg.msg"
   "msg/EncoderMsg.msg"
   "msg/InitializeParams.msg"
+  "msg/ParsecZoneMsg.msg"
   "srv/ControlImu.srv"
   "srv/SetData.srv"
+  DEPENDENCIES std_msgs
 )
 
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
@@ -48,6 +50,7 @@ set(studica_control_HDRS
   include/studica_control/sharp_component.hpp
   include/studica_control/titan_component.hpp
   include/studica_control/ultrasonic_component.hpp
+  include/studica_control/parsec_component.hpp
 )
 
 set(dependencies
@@ -121,6 +124,11 @@ ament_target_dependencies(ultrasonic_component ${dependencies})
 target_link_libraries(ultrasonic_component "${cpp_typesupport_target}")
 rclcpp_components_register_nodes(ultrasonic_component "studica_control::Ultrasonic")
 
+add_library(parsec_component SHARED src/components/parsec_component.cpp)
+ament_target_dependencies(parsec_component ${dependencies})
+target_link_libraries(parsec_component "${cpp_typesupport_target}")
+rclcpp_components_register_nodes(parsec_component "studica_control::Parsec")
+
 install(TARGETS
   cobra_component
   dc_encoder_component
@@ -134,6 +142,7 @@ install(TARGETS
   sharp_component
   titan_component
   ultrasonic_component
+  parsec_component
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
@@ -154,6 +163,7 @@ target_link_libraries(manual_composition
   sharp_component
   titan_component
   ultrasonic_component
+  parsec_component
   /usr/local/lib/vmxpi/libvmxpi_hal_cpp.so
   /usr/local/lib/studica_drivers/libstudica_drivers.so
 )
@@ -202,6 +212,7 @@ ament_export_libraries(
   sharp_component
   titan_component
   ultrasonic_component
+  parsec_component
 )
 ament_export_dependencies(${dependencies})
 

--- a/src/studica_control/config/params_template.yaml
+++ b/src/studica_control/config/params_template.yaml
@@ -179,12 +179,12 @@ control_server:
     # -------------------------------------------------------------------------
     parsec:
       enabled: true
-      sensors: ["front_tof"]
-      front_tof:
+      sensors: ["parsec"]
+      parsec:
         transport: can            # can | usb
         can_id: 5                 # CAN only - must match device CANID (0..63)
         serial_port: /dev/ttyACM0 # USB only - use 'ls /dev/ttyACM*' to find your port
-        frame_id: "parsec_front_link"
+        frame_id: "parsec_link"
         publish_rate_hz: 15
         publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
     # -------------------------------------------------------------------------

--- a/src/studica_control/config/params_template.yaml
+++ b/src/studica_control/config/params_template.yaml
@@ -3,8 +3,8 @@
 # Full reference for all available components.
 # Copy any section into params.yaml and set enabled: true to activate it.
 #
-# Multi-instance components (cobra, duty_cycle, dio, encoder, servo, sharp,
-# titan, ultrasonic) support multiple sensors by adding names to the
+# Multi-instance components (cobra, duty_cycle, dio, encoder, parsec, servo,
+# sharp, titan, ultrasonic) support multiple sensors by adding names to the
 # "sensors" list and adding a matching config block for each name.
 #
 # Single-instance components (gamepad, imu) have a flat config.
@@ -159,6 +159,34 @@ control_server:
         port: 22      # VMX analog input channel
         frame_id: "sharp_link"  # TF frame for the Range message
 
+    # -------------------------------------------------------------------------
+    # Parsec — multi-zone ToF sensor (VL53L8CX, 16 or 64 zones)
+    #
+    # transport: can (default, VMX CAN bus) or usb (Pi USB port, /dev/ttyACM0)
+    #
+    # Topics (publish):
+    #   /<name>/min_range (sensor_msgs/Range) — always on; nearest valid zone in metres
+    # Optional outputs (publish_outputs — pick one, two, or all three):
+    #   zones      — /<name>/zones      (studica_control/ParsecZoneMsg) int16[] mm, easy debug
+    #   depth      — /<name>/depth      (sensor_msgs/Image, 16UC1) 4x4 or 8x8 grid for RViz
+    #   pointcloud — /<name>/pointcloud (sensor_msgs/PointCloud2) 3D points in frame_id
+    #
+    # Service: /<name>/parsec_cmd (SetData)
+    #   Commands: get_config, get_zone_distance, get_min_distance
+    #   get_zone_distance uses initparams.n_encoder as the zone index (0..zones-1)
+    #
+    # USB on Pi: add user to dialout — sudo usermod -aG dialout $USER (re-login)
+    # -------------------------------------------------------------------------
+    parsec:
+      enabled: true
+      sensors: ["front_tof"]
+      front_tof:
+        transport: can            # can | usb
+        can_id: 5                 # CAN only - must match device CANID (0..63)
+        serial_port: /dev/ttyACM0 # USB only - use 'ls /dev/ttyACM*' to find your port
+        frame_id: "parsec_front_link"
+        publish_rate_hz: 15
+        publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
     # -------------------------------------------------------------------------
     # DIO — digital input or output pin
     #

--- a/src/studica_control/config/params_template.yaml
+++ b/src/studica_control/config/params_template.yaml
@@ -167,8 +167,8 @@ control_server:
     # Topics (publish):
     #   /<name>/min_range (sensor_msgs/Range) — always on; nearest valid zone in metres
     # Optional outputs (publish_outputs — pick one, two, or all three):
-    #   zones      — /<name>/zones      (studica_control/ParsecZoneMsg) int16[] mm, easy debug
-    #   depth      — /<name>/depth      (sensor_msgs/Image, 16UC1) 4x4 or 8x8 grid for RViz
+    #   zones      — /<name>/zones      (ParsecZoneMsg) int16[] mm — human-readable in topic echo
+    #   grid       — /<name>/grid       (sensor_msgs/Image 16UC1) mm as raw pixels — use RViz/cv_bridge, not topic echo
     #   pointcloud — /<name>/pointcloud (sensor_msgs/PointCloud2) 3D points in frame_id
     #
     # Service: /<name>/parsec_cmd (SetData)
@@ -186,7 +186,7 @@ control_server:
         serial_port: /dev/ttyACM0 # USB only - use 'ls /dev/ttyACM*' to find your port
         frame_id: "parsec_link"
         publish_rate_hz: 15
-        publish_outputs: ["zones", "depth", "pointcloud"]  # any of: zones, depth, pointcloud
+        publish_outputs: ["zones", "grid", "pointcloud"]  # any of: zones, grid, pointcloud
     # -------------------------------------------------------------------------
     # DIO — digital input or output pin
     #

--- a/src/studica_control/config/params_template.yaml
+++ b/src/studica_control/config/params_template.yaml
@@ -160,7 +160,7 @@ control_server:
         frame_id: "sharp_link"  # TF frame for the Range message
 
     # -------------------------------------------------------------------------
-    # Parsec — multi-zone ToF sensor (VL53L8CX, 16 or 64 zones)
+    # Parsec — multi-zone ToF sensor (16 or 64 zones)
     #
     # transport: can (default, VMX CAN bus) or usb (Pi USB port, /dev/ttyACM0)
     #

--- a/src/studica_control/include/studica_control/parsec_component.hpp
+++ b/src/studica_control/include/studica_control/parsec_component.hpp
@@ -4,8 +4,8 @@
  * ROS2 component for the Studica Parsec multi-zone ToF sensor (CAN or USB).
  *
  * topics (publish, optional via publish_outputs):
- *   /<name>/zones      (studica_control/ParsecZoneMsg) - int16[] fdist in mm
- *   /<name>/depth      (sensor_msgs/Image, 16UC1) - 4x4 or 8x8 grid, mm per pixel
+ *   /<name>/zones      (studica_control/ParsecZoneMsg) - int16[] fdist in mm (readable in topic echo)
+ *   /<name>/grid       (sensor_msgs/Image, 16UC1) - 4x4 or 8x8 grid; mm per pixel as raw bytes (use RViz/cv_bridge)
  *   /<name>/pointcloud (sensor_msgs/PointCloud2) - one point per zone in frame_id
  *   /<name>/min_range  (sensor_msgs/Range) - nearest valid zone distance in metres
  *
@@ -18,7 +18,7 @@
  *   transport     - can (default) or usb
  *   can_id        - CAN only; device CAN ID 0..63
  *   serial_port   - USB only; e.g. /dev/ttyACM0
- *   publish_outputs - zones, depth, pointcloud (any combination)
+ *   publish_outputs - zones, grid, pointcloud (any combination)
  */
 
 #ifndef PARSEC_COMPONENT_H
@@ -50,7 +50,7 @@ enum class ParsecTransport {
 
 struct ParsecPublishOutputs {
     bool zones{false};
-    bool depth{false};
+    bool grid{false};
     bool pointcloud{false};
 };
 
@@ -82,7 +82,7 @@ private:
     uint8_t last_zones_{0};
 
     rclcpp::Publisher<studica_control::msg::ParsecZoneMsg>::SharedPtr zones_publisher_;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_publisher_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr grid_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr min_range_publisher_;
     rclcpp::Service<studica_control::srv::SetData>::SharedPtr service_;
@@ -104,7 +104,7 @@ private:
     static int16_t find_min_valid_distance(const int16_t *fdist, int count);
     static int resolution_zone_count(uint8_t zones_reported);
     static void grid_size_from_zones(int resolution_zones, uint32_t &width, uint32_t &height);
-    static sensor_msgs::msg::Image build_depth_image(
+    static sensor_msgs::msg::Image build_grid_image(
         const rclcpp::Time &stamp, const std::string &frame_id,
         const int16_t *fdist, int resolution_zones);
     static sensor_msgs::msg::PointCloud2 build_point_cloud(

--- a/src/studica_control/include/studica_control/parsec_component.hpp
+++ b/src/studica_control/include/studica_control/parsec_component.hpp
@@ -1,0 +1,117 @@
+/*
+ * parsec_component.hpp
+ *
+ * ROS2 component for the Studica Parsec multi-zone ToF sensor (CAN or USB).
+ *
+ * topics (publish, optional via publish_outputs):
+ *   /<name>/zones      (studica_control/ParsecZoneMsg) - int16[] fdist in mm
+ *   /<name>/depth      (sensor_msgs/Image, 16UC1) - 4x4 or 8x8 grid, mm per pixel
+ *   /<name>/pointcloud (sensor_msgs/PointCloud2) - one point per zone in frame_id
+ *   /<name>/min_range  (sensor_msgs/Range) - nearest valid zone distance in metres
+ *
+ * service: /<name>/parsec_cmd (studica_control/SetData)
+ *   get_config          - firmware version and CAN ID (CAN) or GETCONFIG line (USB)
+ *   get_zone_distance   - distance for zone index in initparams.n_encoder (mm)
+ *   get_min_distance    - nearest valid zone distance (mm)
+ *
+ * params (per sensor in params.yaml):
+ *   transport     - can (default) or usb
+ *   can_id        - CAN only; device CAN ID 0..63
+ *   serial_port   - USB only; e.g. /dev/ttyACM0
+ *   publish_outputs - zones, depth, pointcloud (any combination)
+ */
+
+#ifndef PARSEC_COMPONENT_H
+#define PARSEC_COMPONENT_H
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/range.hpp>
+
+#include "parsec.hpp"
+#include "parsec_usb.hpp"
+#include "studica_control/msg/parsec_zone_msg.hpp"
+#include "studica_control/srv/set_data.hpp"
+#include "VMXPi.h"
+
+namespace studica_control {
+
+enum class ParsecTransport {
+    Can,
+    Usb,
+};
+
+struct ParsecPublishOutputs {
+    bool zones{false};
+    bool depth{false};
+    bool pointcloud{false};
+};
+
+class Parsec : public rclcpp::Node {
+public:
+    static std::vector<std::shared_ptr<rclcpp::Node>> initialize(
+        rclcpp::Node *control, std::shared_ptr<VMXPi> vmx);
+
+    explicit Parsec(const rclcpp::NodeOptions &options);
+
+    Parsec(std::shared_ptr<VMXPi> vmx, const std::string &name,
+           ParsecTransport transport, uint8_t can_id, const std::string &serial_port,
+           const std::string &frame_id, int publish_rate_hz,
+           const std::vector<std::string> &publish_outputs);
+
+    ~Parsec();
+
+private:
+    ParsecTransport transport_{ParsecTransport::Can};
+    std::shared_ptr<studica_driver::Parsec> parsec_can_;
+    std::shared_ptr<studica_driver::ParsecUsb> parsec_usb_;
+    std::shared_ptr<VMXPi> vmx_;
+    std::string frame_id_;
+    std::string usb_config_line_;
+    int publish_rate_hz_;
+    ParsecPublishOutputs outputs_;
+
+    std::array<int16_t, 64> last_fdist_{};
+    uint8_t last_zones_{0};
+
+    rclcpp::Publisher<studica_control::msg::ParsecZoneMsg>::SharedPtr zones_publisher_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_publisher_;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_publisher_;
+    rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr min_range_publisher_;
+    rclcpp::Service<studica_control::srv::SetData>::SharedPtr service_;
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    void cmd_callback(std::shared_ptr<studica_control::srv::SetData::Request> request,
+                      std::shared_ptr<studica_control::srv::SetData::Response> response);
+
+    void cmd(const std::string &params,
+             const studica_control::srv::SetData::Request &request,
+             std::shared_ptr<studica_control::srv::SetData::Response> response);
+
+    void publish_zones();
+    bool read_fdist(uint8_t *seq, uint8_t *zones, int16_t *fdist, int max_zones, int *filled_out);
+
+    static ParsecTransport parse_transport(const std::string &value);
+    static ParsecPublishOutputs parse_publish_outputs(const std::vector<std::string> &names);
+    static bool is_valid_distance_mm(int16_t d);
+    static int16_t find_min_valid_distance(const int16_t *fdist, int count);
+    static int resolution_zone_count(uint8_t zones_reported);
+    static void grid_size_from_zones(int resolution_zones, uint32_t &width, uint32_t &height);
+    static sensor_msgs::msg::Image build_depth_image(
+        const rclcpp::Time &stamp, const std::string &frame_id,
+        const int16_t *fdist, int resolution_zones);
+    static sensor_msgs::msg::PointCloud2 build_point_cloud(
+        const rclcpp::Time &stamp, const std::string &frame_id,
+        const int16_t *fdist, int resolution_zones);
+};
+
+} // namespace studica_control
+
+#endif // PARSEC_COMPONENT_H

--- a/src/studica_control/msg/ParsecZoneMsg.msg
+++ b/src/studica_control/msg/ParsecZoneMsg.msg
@@ -1,0 +1,5 @@
+# Multi-zone ToF distances from Parsec (mm). -1 = disabled, -2 = invalid.
+std_msgs/Header header
+uint8 seq
+uint8 zones          # 16 or 64
+int16[] fdist        # length == zones

--- a/src/studica_control/src/components/examples/cpp/parsec_example.cpp
+++ b/src/studica_control/src/components/examples/cpp/parsec_example.cpp
@@ -1,0 +1,135 @@
+/*
+ * parsec_example.cpp
+ *
+ * Subscribe to multi-zone ToF readings published by the Parsec component.
+ * Prints nearest valid distance and a compact zone grid for 100 frames, then exits.
+ * Polls get_min_distance via service every 5 seconds.
+ *
+ * Run:      ros2 run studica_control parsec_example
+ * Requires: studica_launch.py running, parsec enabled in params.yaml
+ *           sensors: ["parsec"]  (name must match SENSOR below)
+ *
+ * Topics subscribed:
+ *   /parsec/zones     (studica_control/ParsecZoneMsg)
+ *   /parsec/min_range (sensor_msgs/Range)
+ * Service: /parsec/parsec_cmd (studica_control/SetData)
+ *   Commands: get_config, get_zone_distance, get_min_distance
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/range.hpp"
+#include "studica_control/msg/parsec_zone_msg.hpp"
+#include "studica_control/srv/set_data.hpp"
+
+using namespace std::chrono_literals;
+
+static const std::string SENSOR = "parsec";
+static constexpr int kMaxPrints = 100;
+
+class ParsecExample : public rclcpp::Node {
+public:
+    ParsecExample() : Node("parsec_example") {
+        zones_sub_ = create_subscription<studica_control::msg::ParsecZoneMsg>(
+            "/" + SENSOR + "/zones", 10,
+            std::bind(&ParsecExample::on_zones, this, std::placeholders::_1));
+
+        range_sub_ = create_subscription<sensor_msgs::msg::Range>(
+            "/" + SENSOR + "/min_range", 10,
+            std::bind(&ParsecExample::on_min_range, this, std::placeholders::_1));
+
+        client_ = create_client<studica_control::srv::SetData>("/" + SENSOR + "/parsec_cmd");
+        poll_timer_ = create_wall_timer(5s, std::bind(&ParsecExample::poll_service, this));
+
+        RCLCPP_INFO(get_logger(), "listening on /%s/zones and /%s/min_range",
+                    SENSOR.c_str(), SENSOR.c_str());
+    }
+
+private:
+    static bool is_valid_mm(int16_t d) { return d >= 1 && d <= 4000; }
+
+    void on_zones(const studica_control::msg::ParsecZoneMsg::SharedPtr msg) {
+        const int side = (msg->zones == 64) ? 8 : 4;
+        const int center = msg->zones / 2;
+        const int16_t center_mm =
+            (center < static_cast<int>(msg->fdist.size())) ? msg->fdist[static_cast<size_t>(center)] : -2;
+
+        RCLCPP_INFO(get_logger(), "%3d | zones seq=%u count=%u center=%d mm",
+                    print_count_, msg->seq, msg->zones, center_mm);
+
+        for (int row = 0; row < side; ++row) {
+            std::string line = "  ";
+            for (int col = 0; col < side; ++col) {
+                const size_t idx = static_cast<size_t>(row * side + col);
+                if (idx >= msg->fdist.size()) {
+                    break;
+                }
+                const int16_t d = msg->fdist[idx];
+                char cell[16];
+                if (d == -1) {
+                    std::snprintf(cell, sizeof(cell), "%7s", "off");
+                } else if (d == -2 || !is_valid_mm(d)) {
+                    std::snprintf(cell, sizeof(cell), "%7s", "---");
+                } else {
+                    std::snprintf(cell, sizeof(cell), "%4d mm", d);
+                }
+                line += cell;
+                if (col + 1 < side) {
+                    line += ' ';
+                }
+            }
+            RCLCPP_INFO(get_logger(), "%s", line.c_str());
+        }
+
+        ++print_count_;
+        if (print_count_ >= kMaxPrints) {
+            RCLCPP_INFO(get_logger(), "printed %d frames, exiting", kMaxPrints);
+            rclcpp::shutdown();
+        }
+    }
+
+    void on_min_range(const sensor_msgs::msg::Range::SharedPtr msg) {
+        if (std::isinf(msg->range)) {
+            RCLCPP_WARN(get_logger(), "no valid zones in frame");
+        } else {
+            RCLCPP_INFO(get_logger(), "nearest valid zone: %.3f m", msg->range);
+        }
+    }
+
+    void poll_service() {
+        if (!client_->wait_for_service(1s)) {
+            RCLCPP_WARN(get_logger(), "parsec_cmd service not available");
+            return;
+        }
+        auto req = std::make_shared<studica_control::srv::SetData::Request>();
+        req->params = "get_min_distance";
+        client_->async_send_request(req,
+            [this](rclcpp::Client<studica_control::srv::SetData>::SharedFuture f) {
+                const auto resp = f.get();
+                if (resp->success) {
+                    RCLCPP_INFO(get_logger(), "service get_min_distance: %s mm", resp->message.c_str());
+                } else {
+                    RCLCPP_WARN(get_logger(), "service get_min_distance failed: %s",
+                                resp->message.c_str());
+                }
+            });
+    }
+
+    rclcpp::Subscription<studica_control::msg::ParsecZoneMsg>::SharedPtr zones_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::Range>::SharedPtr range_sub_;
+    rclcpp::Client<studica_control::srv::SetData>::SharedPtr client_;
+    rclcpp::TimerBase::SharedPtr poll_timer_;
+    int print_count_{0};
+};
+
+int main(int argc, char *argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<ParsecExample>());
+    rclcpp::shutdown();
+    return 0;
+}
+

--- a/src/studica_control/src/components/examples/python/parsec_example.py
+++ b/src/studica_control/src/components/examples/python/parsec_example.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Parsec — subscribe to multi-zone ToF readings (100 frames, then exit).
+
+Run:  ros2 run studica_control parsec_example.py
+Requires: studica_launch.py running, parsec enabled in params.yaml
+          sensors: ["parsec"]  (name must match SENSOR below)
+
+Topics:
+  /parsec/zones     (studica_control/ParsecZoneMsg)
+  /parsec/min_range (sensor_msgs/Range)
+Service: /parsec/parsec_cmd (SetData)
+  Commands: get_config, get_zone_distance, get_min_distance
+"""
+import math
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Range
+from studica_control.msg import ParsecZoneMsg
+from studica_control.srv import SetData
+
+SENSOR = 'parsec'
+MAX_PRINTS = 100
+
+
+def _zone_cell(d: int) -> str:
+    if d == -1:
+        return '    off'
+    if d == -2 or d < 1 or d > 4000:
+        return '    ---'
+    return f'{d:4d} mm'
+
+
+class ParsecExample(Node):
+    def __init__(self):
+        super().__init__('parsec_example')
+        self.create_subscription(ParsecZoneMsg, f'/{SENSOR}/zones', self.on_zones, 10)
+        self.create_subscription(Range, f'/{SENSOR}/min_range', self.on_min_range, 10)
+        self.client = self.create_client(SetData, f'/{SENSOR}/parsec_cmd')
+        self.create_timer(5.0, self.poll_service)
+        self.print_count = 0
+        self.get_logger().info(f'Listening on /{SENSOR}/zones and /{SENSOR}/min_range')
+
+    def on_zones(self, msg: ParsecZoneMsg):
+        side = 8 if msg.zones == 64 else 4
+        center = msg.zones // 2
+        center_mm = msg.fdist[center] if center < len(msg.fdist) else -2
+        self.get_logger().info(
+            f'{self.print_count:3d} | zones seq={msg.seq} count={msg.zones} center={center_mm} mm'
+        )
+        for row in range(side):
+            row_vals = msg.fdist[row * side:(row + 1) * side]
+            if not row_vals:
+                break
+            line = '  ' + ' '.join(_zone_cell(d) for d in row_vals)
+            self.get_logger().info(line)
+
+        self.print_count += 1
+        if self.print_count >= MAX_PRINTS:
+            self.get_logger().info(f'printed {MAX_PRINTS} frames, exiting')
+            rclpy.shutdown()
+
+    def on_min_range(self, msg: Range):
+        if math.isinf(msg.range):
+            self.get_logger().warn('no valid zones in frame')
+        else:
+            self.get_logger().info(f'nearest valid zone: {msg.range:.3f} m')
+
+    def poll_service(self):
+        if not self.client.wait_for_service(timeout_sec=1.0):
+            self.get_logger().warn('parsec_cmd service not available')
+            return
+        req = SetData.Request()
+        req.params = 'get_min_distance'
+        future = self.client.call_async(req)
+        future.add_done_callback(self._on_service_response)
+
+    def _on_service_response(self, future):
+        resp = future.result()
+        if resp.success:
+            self.get_logger().info(f'service get_min_distance: {resp.message} mm')
+        else:
+            self.get_logger().warn(f'service get_min_distance failed: {resp.message}')
+
+
+def main():
+    rclpy.init()
+    rclpy.spin(ParsecExample())
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/studica_control/src/components/parsec_component.cpp
+++ b/src/studica_control/src/components/parsec_component.cpp
@@ -54,7 +54,7 @@ std::vector<std::shared_ptr<rclcpp::Node>> Parsec::initialize(
         control->declare_parameter<std::string>(frame_id_param, sensor);
         control->declare_parameter<int>(publish_rate_param, 15);
         control->declare_parameter<std::vector<std::string>>(
-            publish_outputs_param, std::vector<std::string>{"depth"});
+            publish_outputs_param, std::vector<std::string>{"grid"});
 
         const ParsecTransport transport =
             parse_transport(control->get_parameter(transport_param).as_string());
@@ -136,8 +136,8 @@ Parsec::Parsec(std::shared_ptr<VMXPi> vmx, const std::string &name,
         zones_publisher_ =
             this->create_publisher<studica_control::msg::ParsecZoneMsg>(name + "/zones", 10);
     }
-    if (outputs_.depth) {
-        depth_publisher_ = this->create_publisher<sensor_msgs::msg::Image>(name + "/depth", 10);
+    if (outputs_.grid) {
+        grid_publisher_ = this->create_publisher<sensor_msgs::msg::Image>(name + "/grid", 10);
     }
     if (outputs_.pointcloud) {
         pointcloud_publisher_ =
@@ -174,8 +174,8 @@ Parsec::Parsec(std::shared_ptr<VMXPi> vmx, const std::string &name,
     if (outputs_.zones) {
         topics << "/" << name << "/zones ";
     }
-    if (outputs_.depth) {
-        topics << "/" << name << "/depth ";
+    if (outputs_.grid) {
+        topics << "/" << name << "/grid ";
     }
     if (outputs_.pointcloud) {
         topics << "/" << name << "/pointcloud ";
@@ -206,15 +206,15 @@ ParsecPublishOutputs Parsec::parse_publish_outputs(const std::vector<std::string
         const std::string key = to_lower(name);
         if (key == "zones") {
             outputs.zones = true;
-        } else if (key == "depth") {
-            outputs.depth = true;
+        } else if (key == "grid") {
+            outputs.grid = true;
         } else if (key == "pointcloud" || key == "points" || key == "cloud") {
             outputs.pointcloud = true;
         }
     }
 
-    if (!outputs.zones && !outputs.depth && !outputs.pointcloud) {
-        outputs.depth = true;
+    if (!outputs.zones && !outputs.grid && !outputs.pointcloud) {
+        outputs.grid = true;
     }
     return outputs;
 }
@@ -343,7 +343,7 @@ void Parsec::grid_size_from_zones(int resolution_zones, uint32_t &width, uint32_
 }
 
 
-sensor_msgs::msg::Image Parsec::build_depth_image(
+sensor_msgs::msg::Image Parsec::build_grid_image(
     const rclcpp::Time &stamp, const std::string &frame_id,
     const int16_t *fdist, int resolution_zones)
 {
@@ -483,8 +483,8 @@ void Parsec::publish_zones()
         zones_msg.fdist.assign(fdist, fdist + resolution_zones);
         zones_publisher_->publish(zones_msg);
     }
-    if (outputs_.depth && depth_publisher_) {
-        depth_publisher_->publish(build_depth_image(stamp, frame_id_, fdist, resolution_zones));
+    if (outputs_.grid && grid_publisher_) {
+        grid_publisher_->publish(build_grid_image(stamp, frame_id_, fdist, resolution_zones));
     }
     if (outputs_.pointcloud && pointcloud_publisher_) {
         pointcloud_publisher_->publish(build_point_cloud(stamp, frame_id_, fdist, resolution_zones));

--- a/src/studica_control/src/components/parsec_component.cpp
+++ b/src/studica_control/src/components/parsec_component.cpp
@@ -1,0 +1,514 @@
+/*
+ * parsec_component.cpp
+ *
+ * ROS2 component for the Studica Parsec multi-zone ToF sensor.
+ * CAN: studica_driver::Parsec::ReadDataStreamCAN2()
+ * USB: studica_driver::ParsecUsb serial binary frames on /dev/ttyACM0
+ */
+
+#include "studica_control/parsec_component.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <vector>
+
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+namespace studica_control {
+
+namespace {
+
+std::string to_lower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+} // namespace
+
+
+std::vector<std::shared_ptr<rclcpp::Node>> Parsec::initialize(
+    rclcpp::Node *control, std::shared_ptr<VMXPi> vmx)
+{
+    std::vector<std::shared_ptr<rclcpp::Node>> parsec_nodes;
+
+    control->declare_parameter<std::vector<std::string>>("parsec.sensors", std::vector<std::string>{});
+    std::vector<std::string> sensor_ids = control->get_parameter("parsec.sensors").as_string_array();
+
+    for (const auto &sensor : sensor_ids) {
+        const std::string prefix = "parsec." + sensor;
+        const std::string transport_param = prefix + ".transport";
+        const std::string can_id_param = prefix + ".can_id";
+        const std::string serial_port_param = prefix + ".serial_port";
+        const std::string frame_id_param = prefix + ".frame_id";
+        const std::string publish_rate_param = prefix + ".publish_rate_hz";
+        const std::string publish_outputs_param = prefix + ".publish_outputs";
+
+        control->declare_parameter<std::string>(transport_param, "can");
+        control->declare_parameter<int>(can_id_param, 0);
+        control->declare_parameter<std::string>(serial_port_param, "/dev/ttyACM0");
+        control->declare_parameter<std::string>(frame_id_param, sensor);
+        control->declare_parameter<int>(publish_rate_param, 15);
+        control->declare_parameter<std::vector<std::string>>(
+            publish_outputs_param, std::vector<std::string>{"depth"});
+
+        const ParsecTransport transport =
+            parse_transport(control->get_parameter(transport_param).as_string());
+        const uint8_t can_id = static_cast<uint8_t>(control->get_parameter(can_id_param).as_int());
+        const std::string serial_port = control->get_parameter(serial_port_param).as_string();
+        const std::string frame_id = control->get_parameter(frame_id_param).as_string();
+        const int publish_rate_hz = control->get_parameter(publish_rate_param).as_int();
+        const std::vector<std::string> publish_outputs =
+            control->get_parameter(publish_outputs_param).as_string_array();
+
+        RCLCPP_INFO(control->get_logger(),
+                    "%s -> transport: %s, frame_id: %s, publish_rate_hz: %d, publish_outputs: [%s]",
+                    sensor.c_str(),
+                    transport == ParsecTransport::Usb ? "usb" : "can",
+                    frame_id.c_str(), publish_rate_hz,
+                    [&publish_outputs]() {
+                        std::ostringstream oss;
+                        for (size_t i = 0; i < publish_outputs.size(); ++i) {
+                            if (i > 0) {
+                                oss << ", ";
+                            }
+                            oss << publish_outputs[i];
+                        }
+                        return oss.str();
+                    }().c_str());
+        if (transport == ParsecTransport::Can) {
+            RCLCPP_INFO(control->get_logger(), "%s -> can_id: %u", sensor.c_str(), can_id);
+        } else {
+            RCLCPP_INFO(control->get_logger(), "%s -> serial_port: %s", sensor.c_str(), serial_port.c_str());
+        }
+
+        parsec_nodes.push_back(std::make_shared<Parsec>(
+            vmx, sensor, transport, can_id, serial_port, frame_id, publish_rate_hz, publish_outputs));
+    }
+
+    return parsec_nodes;
+}
+
+
+Parsec::Parsec(const rclcpp::NodeOptions &options) : Node("parsec", options) {}
+
+
+Parsec::Parsec(std::shared_ptr<VMXPi> vmx, const std::string &name,
+               ParsecTransport transport, uint8_t can_id, const std::string &serial_port,
+               const std::string &frame_id, int publish_rate_hz,
+               const std::vector<std::string> &publish_outputs)
+    : Node(name),
+      transport_(transport),
+      vmx_(vmx),
+      frame_id_(frame_id),
+      publish_rate_hz_(publish_rate_hz > 0 ? publish_rate_hz : 15),
+      outputs_(parse_publish_outputs(publish_outputs))
+{
+    if (transport_ == ParsecTransport::Usb) {
+        parsec_usb_ = std::make_shared<studica_driver::ParsecUsb>(serial_port);
+        if (!parsec_usb_->IsOpen()) {
+            RCLCPP_ERROR(this->get_logger(), "Parsec USB failed to open %s", serial_port.c_str());
+            return;
+        }
+        if (!parsec_usb_->ConfigureStreaming(publish_rate_hz_)) {
+            RCLCPP_WARN(this->get_logger(), "Parsec USB streaming config failed on %s", serial_port.c_str());
+        }
+        if (parsec_usb_->RequestConfig(&usb_config_line_)) {
+            RCLCPP_INFO(this->get_logger(), "Parsec USB ready on %s: %s",
+                        serial_port.c_str(), usb_config_line_.c_str());
+        } else {
+            RCLCPP_WARN(this->get_logger(), "Parsec USB opened %s but GETCONFIG not received yet",
+                        serial_port.c_str());
+        }
+    } else {
+        parsec_can_ = std::make_shared<studica_driver::Parsec>(can_id, vmx_);
+        if (parsec_can_->GetCanID() != can_id) {
+            RCLCPP_ERROR(this->get_logger(), "Parsec driver failed to init for CAN ID %u", can_id);
+            return;
+        }
+    }
+
+    if (outputs_.zones) {
+        zones_publisher_ =
+            this->create_publisher<studica_control::msg::ParsecZoneMsg>(name + "/zones", 10);
+    }
+    if (outputs_.depth) {
+        depth_publisher_ = this->create_publisher<sensor_msgs::msg::Image>(name + "/depth", 10);
+    }
+    if (outputs_.pointcloud) {
+        pointcloud_publisher_ =
+            this->create_publisher<sensor_msgs::msg::PointCloud2>(name + "/pointcloud", 10);
+    }
+    min_range_publisher_ = this->create_publisher<sensor_msgs::msg::Range>(name + "/min_range", 10);
+
+    service_ = this->create_service<studica_control::srv::SetData>(
+        name + "/parsec_cmd",
+        std::bind(&Parsec::cmd_callback, this, std::placeholders::_1, std::placeholders::_2));
+
+    const int period_ms = std::max(1, 1000 / publish_rate_hz_);
+    timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(period_ms),
+        std::bind(&Parsec::publish_zones, this));
+
+    if (transport_ == ParsecTransport::Can && parsec_can_) {
+        uint8_t config[64] = {0};
+        if (parsec_can_->RequestConfig()) {
+            vmx_->time.DelayMilliseconds(50);
+            if (parsec_can_->GetConfigResponse(config, sizeof(config)) && config[0] != 0) {
+                RCLCPP_INFO(this->get_logger(),
+                            "Parsec ready on CAN ID %u (fw version %u, reported_id %u)",
+                            can_id, config[0], config[4]);
+            } else {
+                RCLCPP_WARN(this->get_logger(),
+                            "Parsec started on CAN ID %u but GETCONFIG response not received yet",
+                            can_id);
+            }
+        }
+    }
+
+    std::ostringstream topics;
+    if (outputs_.zones) {
+        topics << "/" << name << "/zones ";
+    }
+    if (outputs_.depth) {
+        topics << "/" << name << "/depth ";
+    }
+    if (outputs_.pointcloud) {
+        topics << "/" << name << "/pointcloud ";
+    }
+    topics << "/" << name << "/min_range";
+
+    RCLCPP_INFO(this->get_logger(), "Parsec topics:%s at %d Hz", topics.str().c_str(), publish_rate_hz_);
+}
+
+
+Parsec::~Parsec() {}
+
+
+ParsecTransport Parsec::parse_transport(const std::string &value)
+{
+    const std::string key = to_lower(value);
+    if (key == "usb" || key == "serial") {
+        return ParsecTransport::Usb;
+    }
+    return ParsecTransport::Can;
+}
+
+
+ParsecPublishOutputs Parsec::parse_publish_outputs(const std::vector<std::string> &names)
+{
+    ParsecPublishOutputs outputs;
+    for (const auto &name : names) {
+        const std::string key = to_lower(name);
+        if (key == "zones") {
+            outputs.zones = true;
+        } else if (key == "depth") {
+            outputs.depth = true;
+        } else if (key == "pointcloud" || key == "points" || key == "cloud") {
+            outputs.pointcloud = true;
+        }
+    }
+
+    if (!outputs.zones && !outputs.depth && !outputs.pointcloud) {
+        outputs.depth = true;
+    }
+    return outputs;
+}
+
+
+void Parsec::cmd_callback(std::shared_ptr<studica_control::srv::SetData::Request> request,
+                          std::shared_ptr<studica_control::srv::SetData::Response> response)
+{
+    cmd(request->params, *request, response);
+}
+
+
+void Parsec::cmd(const std::string &params,
+                 const studica_control::srv::SetData::Request &request,
+                 std::shared_ptr<studica_control::srv::SetData::Response> response)
+{
+    if (params == "get_config") {
+        if (transport_ == ParsecTransport::Usb) {
+            if (!parsec_usb_) {
+                response->success = false;
+                response->message = "USB driver not initialized";
+                return;
+            }
+            std::string line;
+            if (!parsec_usb_->RequestConfig(&line)) {
+                response->success = false;
+                response->message = "no GETCONFIG response";
+                return;
+            }
+            usb_config_line_ = line;
+            response->success = true;
+            response->message = line;
+            return;
+        }
+
+        if (!parsec_can_) {
+            response->success = false;
+            response->message = "CAN driver not initialized";
+            return;
+        }
+        uint8_t config[64] = {0};
+        if (!parsec_can_->RequestConfig()) {
+            response->success = false;
+            response->message = "failed to send GETCONFIG";
+            return;
+        }
+        vmx_->time.DelayMilliseconds(50);
+        const int n = parsec_can_->Read(parsec_can_->GetAddress(17), config, sizeof(config));
+        if (n < 8) {
+            response->success = false;
+            response->message = "no GETCONFIG response";
+            return;
+        }
+        response->success = true;
+        response->message = "version=" + std::to_string(config[0]) +
+                            ", fdist_en=" + std::to_string(config[1]) +
+                            ", can_id=" + std::to_string(config[4]);
+        return;
+    }
+
+    if (params == "get_zone_distance") {
+        const int zone = request.initparams.n_encoder;
+        if (zone < 0 || zone >= static_cast<int>(last_zones_)) {
+            response->success = false;
+            response->message = "invalid zone " + std::to_string(zone);
+            return;
+        }
+        response->success = true;
+        response->message = std::to_string(last_fdist_[static_cast<size_t>(zone)]);
+        return;
+    }
+
+    if (params == "get_min_distance") {
+        const int16_t min_mm = find_min_valid_distance(last_fdist_.data(), last_zones_);
+        if (min_mm < 0) {
+            response->success = false;
+            response->message = "no valid zones";
+            return;
+        }
+        response->success = true;
+        response->message = std::to_string(min_mm);
+        return;
+    }
+
+    response->success = false;
+    response->message = "unknown command '" + params +
+                        "' — use get_config, get_zone_distance, or get_min_distance";
+}
+
+
+bool Parsec::is_valid_distance_mm(int16_t d)
+{
+    return d >= 1 && d <= 4000;
+}
+
+
+int16_t Parsec::find_min_valid_distance(const int16_t *fdist, int count)
+{
+    int16_t min_d = std::numeric_limits<int16_t>::max();
+    bool found = false;
+    for (int i = 0; i < count; ++i) {
+        if (is_valid_distance_mm(fdist[i]) && fdist[i] < min_d) {
+            min_d = fdist[i];
+            found = true;
+        }
+    }
+    return found ? min_d : static_cast<int16_t>(-1);
+}
+
+
+int Parsec::resolution_zone_count(uint8_t zones_reported)
+{
+    return zones_reported > 16 ? 64 : 16;
+}
+
+
+void Parsec::grid_size_from_zones(int resolution_zones, uint32_t &width, uint32_t &height)
+{
+    if (resolution_zones == 64) {
+        width = 8;
+        height = 8;
+    } else {
+        width = 4;
+        height = 4;
+    }
+}
+
+
+sensor_msgs::msg::Image Parsec::build_depth_image(
+    const rclcpp::Time &stamp, const std::string &frame_id,
+    const int16_t *fdist, int resolution_zones)
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+    grid_size_from_zones(resolution_zones, width, height);
+
+    const size_t pixel_count = static_cast<size_t>(width) * static_cast<size_t>(height);
+    std::vector<uint8_t> data(pixel_count * 2, 0);
+
+    for (size_t i = 0; i < pixel_count; ++i) {
+        uint16_t px = 0;
+        if (i < static_cast<size_t>(resolution_zones) && fdist[i] >= 0) {
+            px = static_cast<uint16_t>(fdist[i]);
+        }
+        data[2 * i] = static_cast<uint8_t>(px & 0xFF);
+        data[2 * i + 1] = static_cast<uint8_t>((px >> 8) & 0xFF);
+    }
+
+    sensor_msgs::msg::Image image;
+    image.header.stamp = stamp;
+    image.header.frame_id = frame_id;
+    image.height = height;
+    image.width = width;
+    image.encoding = "16UC1";
+    image.is_bigendian = false;
+    image.step = width * 2;
+    image.data = std::move(data);
+    return image;
+}
+
+
+sensor_msgs::msg::PointCloud2 Parsec::build_point_cloud(
+    const rclcpp::Time &stamp, const std::string &frame_id,
+    const int16_t *fdist, int resolution_zones)
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+    grid_size_from_zones(resolution_zones, width, height);
+
+    int valid_points = 0;
+    for (int i = 0; i < resolution_zones; ++i) {
+        if (fdist[i] >= 0) {
+            ++valid_points;
+        }
+    }
+
+    sensor_msgs::msg::PointCloud2 cloud;
+    cloud.header.stamp = stamp;
+    cloud.header.frame_id = frame_id;
+    cloud.height = 1;
+    cloud.is_bigendian = false;
+    cloud.is_dense = true;
+
+    sensor_msgs::PointCloud2Modifier modifier(cloud);
+    modifier.setPointCloud2FieldsByString(1, "xyz");
+    modifier.resize(static_cast<size_t>(valid_points));
+
+    constexpr double field_of_view = 0.785; // ~45 deg
+    const double tan_half_fov = std::tan(field_of_view * 0.5);
+
+    sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
+    sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
+    sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+
+    for (int i = 0; i < resolution_zones; ++i) {
+        if (fdist[i] < 0) {
+            continue;
+        }
+
+        const uint32_t row = static_cast<uint32_t>(i) / width;
+        const uint32_t col = static_cast<uint32_t>(i) % width;
+        const double u = (static_cast<double>(col) + 0.5) / static_cast<double>(width) - 0.5;
+        const double v = (static_cast<double>(row) + 0.5) / static_cast<double>(height) - 0.5;
+        const double depth_m = static_cast<double>(fdist[i]) / 1000.0;
+
+        *iter_x = static_cast<float>(depth_m * u * 2.0 * tan_half_fov);
+        *iter_y = static_cast<float>(depth_m * v * 2.0 * tan_half_fov);
+        *iter_z = static_cast<float>(depth_m);
+        ++iter_x;
+        ++iter_y;
+        ++iter_z;
+    }
+
+    return cloud;
+}
+
+
+bool Parsec::read_fdist(uint8_t *seq, uint8_t *zones, int16_t *fdist, int max_zones, int *filled_out)
+{
+    if (filled_out == nullptr) {
+        return false;
+    }
+    *filled_out = 0;
+
+    if (transport_ == ParsecTransport::Usb) {
+        if (!parsec_usb_) {
+            return false;
+        }
+        *filled_out = parsec_usb_->ReadLatestFdist(seq, zones, fdist, max_zones);
+        return *filled_out > 0;
+    }
+
+    if (!parsec_can_) {
+        return false;
+    }
+    *filled_out = parsec_can_->ReadDataStreamCAN2(seq, zones, fdist, max_zones);
+    return *filled_out > 0;
+}
+
+
+void Parsec::publish_zones()
+{
+    uint8_t seq = 0;
+    uint8_t zones = 0;
+    int16_t fdist[64] = {0};
+
+    int n = 0;
+    if (!read_fdist(&seq, &zones, fdist, 64, &n) || n <= 0) {
+        return;
+    }
+
+    last_zones_ = static_cast<uint8_t>(n);
+    for (int i = 0; i < n; ++i) {
+        last_fdist_[static_cast<size_t>(i)] = fdist[i];
+    }
+
+    const int resolution_zones = resolution_zone_count(zones);
+    const auto stamp = this->get_clock()->now();
+
+    if (outputs_.zones && zones_publisher_) {
+        studica_control::msg::ParsecZoneMsg zones_msg;
+        zones_msg.header.stamp = stamp;
+        zones_msg.header.frame_id = frame_id_;
+        zones_msg.seq = seq;
+        zones_msg.zones = static_cast<uint8_t>(resolution_zones);
+        zones_msg.fdist.assign(fdist, fdist + resolution_zones);
+        zones_publisher_->publish(zones_msg);
+    }
+    if (outputs_.depth && depth_publisher_) {
+        depth_publisher_->publish(build_depth_image(stamp, frame_id_, fdist, resolution_zones));
+    }
+    if (outputs_.pointcloud && pointcloud_publisher_) {
+        pointcloud_publisher_->publish(build_point_cloud(stamp, frame_id_, fdist, resolution_zones));
+    }
+
+    constexpr double min_range_m = 0.001;  // 1 mm
+    constexpr double max_range_m = 4.0;
+    constexpr double field_of_view = 0.785; // ~45 deg
+
+    const int16_t min_mm = find_min_valid_distance(fdist, n);
+
+    sensor_msgs::msg::Range range_msg;
+    range_msg.header.stamp = stamp;
+    range_msg.header.frame_id = frame_id_;
+    range_msg.radiation_type = sensor_msgs::msg::Range::INFRARED;
+    range_msg.field_of_view = field_of_view;
+    range_msg.min_range = min_range_m;
+    range_msg.max_range = max_range_m;
+    range_msg.range = (min_mm >= 0) ? static_cast<double>(min_mm) / 1000.0 : std::numeric_limits<float>::infinity();
+    min_range_publisher_->publish(range_msg);
+}
+
+
+} // namespace studica_control
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(studica_control::Parsec)

--- a/src/studica_control/src/manual_composition.cpp
+++ b/src/studica_control/src/manual_composition.cpp
@@ -16,6 +16,7 @@
 #include "studica_control/sharp_component.hpp"
 #include "studica_control/titan_component.hpp"
 #include "studica_control/ultrasonic_component.hpp"
+#include "studica_control/parsec_component.hpp"
 #include "VMXPi.h"
 
 class ControlServer : public rclcpp::Node {
@@ -43,6 +44,7 @@ public:
         this->declare_parameter<bool>("sharp.enabled", false);
         this->declare_parameter<bool>("titan.enabled", false);
         this->declare_parameter<bool>("ultrasonic.enabled", false);
+        this->declare_parameter<bool>("parsec.enabled", false);
 
         if (!vmx_ready_) {
             RCLCPP_ERROR(this->get_logger(), "VMX-pi connection failed during startup. Aborting component initialization.");
@@ -64,6 +66,7 @@ public:
         bool sharp_enabled = this->get_parameter("sharp.enabled").as_bool();
         bool titan_enabled = this->get_parameter("titan.enabled").as_bool();
         bool ultrasonic_enabled = this->get_parameter("ultrasonic.enabled").as_bool();
+        bool parsec_enabled = this->get_parameter("parsec.enabled").as_bool();
 
         if (cobra_enabled) {
             auto cobra_nodes = studica_control::Cobra::initialize(this, vmx_);
@@ -118,6 +121,11 @@ public:
         if (ultrasonic_enabled) {
             auto ultrasonic_nodes = studica_control::Ultrasonic::initialize(this, vmx_);
             component_nodes.insert(component_nodes.end(), ultrasonic_nodes.begin(), ultrasonic_nodes.end());
+        }
+
+        if (parsec_enabled) {
+            auto parsec_nodes = studica_control::Parsec::initialize(this, vmx_);
+            component_nodes.insert(component_nodes.end(), parsec_nodes.begin(), parsec_nodes.end());
         }
 
         for (const auto &node : component_nodes) {


### PR DESCRIPTION
- Multi-zone ToF driver over CAN and USB
- ROS2 Topics: default - `/parsec/min_range`, optional - `/parsec/zones`, `parsec/grid`, `parsec/pointcloud`
- Service: `/parsec/parsec_cmd`
- Config: via `params.yaml`
- Standalone driver example (`drivers/examples/parsec_example`) 
- ROS Examples (C++/Python)
- README + `params_template.yaml` updated