### PR TITLE
Titan2 S-Curve PID Expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ Topics are auto-generated from the sensor name. Using `"titan0"` as an example:
 
 | Topic | Type | Description |
 |---|---|---|
-| `/titan0/m_0/cmd` | `std_msgs/Float64` | Duty cycle motor 0, −1.0 to 1.0 |
-| `/titan0/m_1/cmd` | `std_msgs/Float64` | Duty cycle motor 1 |
-| `/titan0/m_2/cmd` | `std_msgs/Float64` | Duty cycle motor 2 |
-| `/titan0/m_3/cmd` | `std_msgs/Float64` | Duty cycle motor 3 |
+| `/titan0/m_N/cmd` | `std_msgs/Float64` | PWM duty cycle, −1.0 to 1.0 (signed for direction). Used when the motor is in PID type 0. |
+| `/titan0/m_N/rpm_cmd` | `std_msgs/Float64` | Target speed in RPM. Used when the motor is in PID type 1 or 2 (closed loop velocity). |
+
+`N` is the motor index, 0 to 3. Every motor listens on both topics, but only the one matching its current PID type takes effect; a command sent to the wrong topic is ignored with a warning. See [Motor Control Modes](#motor-control-modes-pid-types-ramp-profiles-and-autotune) below.
 
 **Topics (publish) — feedback at `encoder_rate_hz` Hz (default 20), topics depend on `encoder_mode`:**
 
@@ -390,6 +390,16 @@ Use the service for configuration and closed-loop control. Direct speed commands
 | `set_target_distance` | `n_encoder`, `int_value` | Closed-loop position in encoder counts |
 | `set_target_angle` | `n_encoder`, `speed` | Drive to target angle in degrees |
 | `set_position_hold` | `n_encoder`, `hold` | Lock motor at current position |
+| `set_pid_type` | `int_value` | Set the control mode for all motors (0 = duty cycle, 1 = manual velocity, 2 = MCV2 velocity) |
+| `set_motor_pid_type` | `n_encoder`, `int_value` | Set the control mode for one motor |
+| `set_sensitivity` | `n_encoder`, `int_value` | How aggressively velocity control reacts (0 to 255) |
+| `set_motor_stop_mode` | `int_value` | How a stopped motor behaves: 0 = coast, 1 = brake |
+| `set_current_limit` | `n_encoder`, `speed` (amps) | Limit how many amps a motor may draw |
+| `autotune` | — | Learn each motor's duty cycle to speed relationship with the robot lifted (wheels spin freely) |
+| `autotune_symmetric` | — | Same, but with the robot on the ground; each motor drives forward then back. Forward travel per step is capped by `autotune_distance_m` |
+| `autotune_motor` | `n_encoder` | Autotune a single motor |
+| `get_target_rpm` | — | Read the target RPM of all 4 motors |
+| `get_controller_temp` | — | Read the controller temperature in Celsius |
 | `configure_encoder` | `n_encoder`, `dist_per_tick` | Override distance per tick at runtime (normally set in params.yaml) |
 | `reset_encoder` | `n_encoder` | Zero one encoder |
 | `invert_motor` | `n_encoder` | Flip positive direction at runtime (normally set in params.yaml) |
@@ -412,6 +422,9 @@ titan:
     motor_update_rate_hz: 50 # how often motor speeds are sent to hardware, in Hz (default 50)
     limit_switches: false    # true = publish /m_N/limit_fwd and /m_N/limit_rev (std_msgs/Bool)
     enable_freshness: false  # true = skip publish on stale CAN frames (encoder, RPM, cypher max, limit switches); warn after 5 consecutive stale reads
+    default_pid_type: 0      # starting control mode for all motors: 0 = duty cycle, 1 = manual velocity, 2 = MCV2 velocity (default 0)
+    scurve_profile: 0        # speed ramp shape for MCV2 velocity: 0 = nav (smooth speed up and slow down), 1 = teleop (smooth speed up, quick stop) (default 0)
+    autotune_distance_m: 1.0 # max forward travel per step during on the ground autotune, in metres, 0.5 to 5.0 (default 1.0)
     m_0:
       encoder_mode: "quadrature"   # "quadrature" or "absolute"
       dist_per_tick: 0.0006830601  # metres per encoder tick (1.0 = raw counts)
@@ -428,7 +441,32 @@ titan:
       dist_per_tick: 0.0006830601
 ```
 
-All per-motor fields default to `encoder_mode: "quadrature"`, `dist_per_tick: 1.0`, and all invert flags `false` if omitted. `encoder_rate_hz` and `motor_update_rate_hz` default to `20` and `50` respectively if omitted.
+All per-motor fields default to `encoder_mode: "quadrature"`, `dist_per_tick: 1.0`, and all invert flags `false` if omitted. `encoder_rate_hz` and `motor_update_rate_hz` default to `20` and `50` respectively if omitted. `default_pid_type` and `scurve_profile` default to `0`, and `autotune_distance_m` defaults to `1.0`.
+
+#### Motor Control Modes: PID Types, Ramp Profiles, and Autotune
+
+**PID type** Pick the starting mode with `default_pid_type`, or change it while running with the `set_pid_type` (all motors) or `set_motor_pid_type` (one motor) service command.
+
+| PID type | Send commands to | What it does |
+|---|---|---|
+| `0` duty cycle (open loop) | `/m_N/cmd` | You set the PWM duty cycle directly, −1.0 to 1.0, where the sign is the direction. The simplest mode. The motor drives at that level and does not regulate its actual speed, so load and battery voltage will affect how fast it really turns. |
+| `1` manual velocity | `/m_N/rpm_cmd` | Closed loop speed control where you supply the gains yourself. You tune the kP, kI, kD, and kF values in the Studica Hardware Manager until the motor holds speed the way you want. |
+| `2` MCV2 velocity | `/m_N/rpm_cmd` | The easier closed loop speed control option. You give a target RPM and the controller adjusts the duty cycle to hold it, smoothing the change in speed using the ramp profile below. |
+
+**If you want closed loop control, we recommend PID type 2 (MCV2).** It can set its own gains with autotune (below), so you do not have to find kP, kI, kD, and kF by hand. Choose type 1 only if you specifically want to tune those values yourself in the Studica Hardware Manager.
+
+**Ramp profile (MCV2 only).** Set with `scurve_profile`. Both profiles ease the motor up to speed smoothly so the wheels do not slip and the gears are not jolted; they differ only in how the robot slows down.
+
+- `0` nav: the speed eases in and eases out gently in both directions. Best for autonomous driving and odometry, where smooth and predictable motion matters most.
+- `1` teleop: the speed still eases in when you push the stick, but slows quickly when you let go. Best for driving by hand, where you want the robot to feel responsive and stop promptly.
+
+**Autotune — let the Titan learn each motor.** Closed loop speed control works best when the controller knows how much duty cycle produces how much speed for your exact motors and gearing. Autotune measures this relationship for you.
+
+- `autotune` runs with the robot lifted so the wheels spin freely. Each motor only spins forward.
+- `autotune_symmetric` runs with the robot on the ground. For each duty point a motor rolls forward, takes its reading, then returns to its start under so the robot stays roughly in place. A point ends as soon as its reading is accurate enough, so most points finish early and use only a fraction of the allowed distance.
+- `autotune_motor` tunes a single motor.
+
+**`autotune_distance_m` is a safety cap, not a target distance.** It sets the farthest a single duty point may roll forward before the sweep stops waiting and brings the motor home. Points that settle quickly stop well short of it; the cap only ever limits the fast, high duty points, which are the ones that need the most room to read cleanly. So give it as much space as you safely have. Default `1.0` m, range `0.5` to `5.0` m. It changes nothing else about tuning, and the lifted `autotune` ignores it entirely.
 
 ---
 

--- a/drivers/titan.cpp
+++ b/drivers/titan.cpp
@@ -728,6 +728,14 @@ void Titan::SetTargetVelocity(uint8_t motor, float velocityRpm)
 {
     if (motor >= 4)
         return;
+    if (motor == 0 && invertMotor0)
+        velocityRpm *= -1.0f;
+    else if (motor == 1 && invertMotor1)
+        velocityRpm *= -1.0f;
+    else if (motor == 2 && invertMotor2)
+        velocityRpm *= -1.0f;
+    else if (motor == 3 && invertMotor3)
+        velocityRpm *= -1.0f;
     float rpmScaled = velocityRpm * kRpmScale;
     int32_t rpm32 =
         (rpmScaled >= 0.0f) ? static_cast<int32_t>(rpmScaled + 0.5f) : static_cast<int32_t>(rpmScaled - 0.5f);
@@ -843,9 +851,13 @@ void Titan::SetMotorPIDType(uint8_t motor, uint8_t type)
     Write(GetAddress(SET_PID_TYPE), data, 0);
 }
 
-void Titan::AutotuneAll()
+void Titan::AutotuneAll(const char *signs)
 {
     uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    if (signs) {
+        for (int i = 0; i < 4; i++)
+            data[i] = (signs[i] == '-') ? (uint8_t)'-' : (uint8_t)'+';
+    }
     Write(GetAddress(AUTOTUNE_ALL), data, 0);
 }
 
@@ -865,6 +877,15 @@ void Titan::SetSensitivity(uint8_t motor, uint8_t sensitivity)
     data[0] = motor;
     data[1] = sensitivity;
     Write(GetAddress(SET_SENSITIVITY), data, 0);
+}
+
+void Titan::SetRampProfile(uint8_t profile)
+{
+    if (profile > 1)   // 0 = nav (symmetric S-curve), 1 = teleop (smooth accel, instant decel)
+        return;
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = profile;
+    Write(GetAddress(SET_RAMP_PROFILE), data, 0);
 }
 
 void Titan::SetCANSensorOsDelay(uint16_t periodMs)

--- a/drivers/titan.cpp
+++ b/drivers/titan.cpp
@@ -881,11 +881,35 @@ void Titan::SetSensitivity(uint8_t motor, uint8_t sensitivity)
 
 void Titan::SetRampProfile(uint8_t profile)
 {
-    if (profile > 1)   // 0 = nav (symmetric S-curve), 1 = teleop (smooth accel, instant decel)
+    if (profile > 1)   // 0 = nav (symmetric S-curve), 1 = teleop (smooth accel, fast jerk-limited decel)
         return;
     uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
     data[0] = profile;
     Write(GetAddress(SET_RAMP_PROFILE), data, 0);
+}
+
+void Titan::SetAutotuneDistance(float metres)
+{
+    // Forward-distance cap for the symmetric autotune sweep. Clamp to the supported 0.5-5.0 m
+    // range, then send as a single byte in 0.1 m units (firmware applies its own sane bound).
+    if (metres < 0.5f) metres = 0.5f;
+    if (metres > 5.0f) metres = 5.0f;
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = static_cast<uint8_t>(metres * 10.0f + 0.5f);
+    Write(GetAddress(SET_AUTOTUNE_DISTANCE), data, 0);
+}
+
+void Titan::SetWheelDiameter(float metres)
+{
+    /* Wheel diameter for the autotune metres->counts conversion. Clamp to a sane range, then send
+     * as U16 LE millimetres (firmware applies its own 0 < d <= 1.0 m bound). */
+    if (metres < 0.01f) metres = 0.01f;
+    if (metres > 1.0f)  metres = 1.0f;
+    uint16_t mm = static_cast<uint16_t>(metres * 1000.0f + 0.5f);
+    uint8_t data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    data[0] = static_cast<uint8_t>(mm & 0xFFu);
+    data[1] = static_cast<uint8_t>((mm >> 8) & 0xFFu);
+    Write(GetAddress(SET_WHEEL_DIAMETER), data, 0);
 }
 
 void Titan::SetCANSensorOsDelay(uint16_t periodMs)

--- a/drivers/titan.hpp
+++ b/drivers/titan.hpp
@@ -60,6 +60,7 @@ namespace studica_driver
 #define GET_TARGET_RPM BASE + (OFFSET * 25)
 #define SET_CAN_SENSOR_OS_DELAY BASE + (OFFSET * 26)
 #define AUTOTUNE_MOTOR BASE + (OFFSET * 27)
+#define SET_RAMP_PROFILE BASE + (OFFSET * 28)
 #define CYPHER_OUTPUT BASE + (OFFSET * 36)
 #define ENCODER_0 BASE + (OFFSET * 37)
 #define ENCODER_1 BASE + (OFFSET * 38)
@@ -152,9 +153,13 @@ namespace studica_driver
             void SetPIDType(uint8_t type);
             /** Per-motor PID type (0=OFF, 1=legacy, 2=MCV2 cascade). */
             void SetMotorPIDType(uint8_t motor, uint8_t type);
-            void AutotuneAll();
+            /** signs=nullptr: forward-only sweep (use with robot lifted). 
+            signs[4] of '+','-': symmetric sweep (can use with robot on the ground). */
+            void AutotuneAll(const char *signs = nullptr);
             void AutotuneMotor(uint8_t motor);
             void SetSensitivity(uint8_t motor, uint8_t sensitivity);
+            /** Velocity ramp profile (MCV2): 0=nav (symmetric S-curve), 1=teleop (smooth accel, instant decel). Global, runtime only. */
+            void SetRampProfile(uint8_t profile);
             /** Set CAN sensor transmit task period in ms (firmware minimum 5). Persisted to EEPROM. */
             void SetCANSensorOsDelay(uint16_t periodMs);
             void DisableMotor(uint8_t motor);

--- a/drivers/titan.hpp
+++ b/drivers/titan.hpp
@@ -61,6 +61,9 @@ namespace studica_driver
 #define SET_CAN_SENSOR_OS_DELAY BASE + (OFFSET * 26)
 #define AUTOTUNE_MOTOR BASE + (OFFSET * 27)
 #define SET_RAMP_PROFILE BASE + (OFFSET * 28)
+#define SET_RAMP_PROFILE           BASE + (OFFSET * 28)
+#define SET_WHEEL_DIAMETER         BASE + (OFFSET * 29)
+#define SET_AUTOTUNE_DISTANCE      BASE + (OFFSET * 30)
 #define CYPHER_OUTPUT BASE + (OFFSET * 36)
 #define ENCODER_0 BASE + (OFFSET * 37)
 #define ENCODER_1 BASE + (OFFSET * 38)
@@ -158,8 +161,15 @@ namespace studica_driver
             void AutotuneAll(const char *signs = nullptr);
             void AutotuneMotor(uint8_t motor);
             void SetSensitivity(uint8_t motor, uint8_t sensitivity);
-            /** Velocity ramp profile (MCV2): 0=nav (symmetric S-curve), 1=teleop (smooth accel, instant decel). Global, runtime only. */
+            /** Velocity ramp profile (MCV2): 0=nav (symmetric S-curve), 1=teleop (smooth accel, fast jerk-limited decel). Global, runtime only. */
             void SetRampProfile(uint8_t profile);
+            /** Autotune forward-distance cap (symmetric sweep), in metres. Clamped to 0.5–5.0 m before
+                transmit; applied at the next AutotuneAll/AutotuneMotor start. Runtime only (no EEPROM). */
+            void SetAutotuneDistance(float metres);
+            /** Autotune wheel diameter, in metres (metres→encoder-counts conversion). Clamped to 0.01–1.0 m
+            before transmit; applied at the next AutotuneAll/AutotuneMotor start. Runtime only (no EEPROM).
+            Default on device is 100 mm (Studica wheel); ROS does not set this today. */
+            void SetWheelDiameter(float metres);
             /** Set CAN sensor transmit task period in ms (firmware minimum 5). Persisted to EEPROM. */
             void SetCANSensorOsDelay(uint16_t periodMs);
             void DisableMotor(uint8_t motor);

--- a/src/studica_control/config/params_template.yaml
+++ b/src/studica_control/config/params_template.yaml
@@ -43,6 +43,9 @@ control_server:
         motor_update_rate_hz: 50  # how often motor speeds are sent to hardware, in Hz (default 50)
         limit_switches: false     # true = publish /m_N/limit_fwd and /m_N/limit_rev (std_msgs/Bool)
         enable_freshness: false   # true = skip publish on stale CAN frames (encoder, RPM, cypher max, limit switch); warn after 5 consecutive stale reads
+        default_pid_type: 0       # starting control mode for all motors: 0 = duty cycle, 1 = manual velocity (tune kP/kI/kD/kF in Studica Hardware Manager), 2 = MCV2 velocity (supports autotune, recommended)
+        scurve_profile: 0         # speed ramp shape for MCV2 velocity: 0 = nav (smooth speed up and slow down), 1 = teleop (smooth speed up, quick stop)
+        autotune_distance_m: 1.0  # max forward travel per step during on the ground (symmetric) autotune, 0.5 to 5.0 metres
         m_0:
           encoder_mode: "quadrature"  # "quadrature" or "absolute"
           dist_per_tick: 1.0          # metres per encoder tick (1.0 = raw counts)

--- a/src/studica_control/include/studica_control/titan_component.hpp
+++ b/src/studica_control/include/studica_control/titan_component.hpp
@@ -15,10 +15,10 @@
  *     /titan0/m_N/angle    (std_msgs/Float64) — absolute angle in degrees, 20hz
  *
  * command topics (always present regardless of encoder mode):
- *     /titan0/m_0/cmd  (std_msgs/Float64) — duty cycle motor 0, -1.0 to 1.0
+ *     /titan0/m_0/cmd      (std_msgs/Float64) — duty cycle motor 0, -1.0 to 1.0 (pid type 0)
+ *     /titan0/m_0/rpm_cmd  (std_msgs/Float64) — target rpm (pid type 1 or 2)
  *     /titan0/m_1/cmd  ...
- *     /titan0/m_2/cmd  ...
- *     /titan0/m_3/cmd  ...
+ *     /titan0/m_1/rpm_cmd  ...
  *
  * service: /titan0/titan_cmd (studica_control/SetData)
  *   use the service for configuration and closed-loop control.
@@ -58,8 +58,10 @@
  *                            requires: int_value
  *     set_sensitivity      — tune how aggressively the pid responds (0–255)
  *                            requires: n_encoder, int_value
- *     autotune             — automatically tune pid for all motors
- *     autotune_motor       — automatically tune pid for one motor
+ *     autotune             — autotune duty->rpm feedforward curve, all motors (lifted / forward-only)
+ *     autotune_symmetric   — symmetric back-and-forth autotune on the ground; signs from
+ *                            each motor's invert_motor param (studica_params.yaml).
+ *     autotune_motor       — autotune one motor
  *                            requires: n_encoder
  *     set_motor_pid_type   — per-motor pid type (0=OFF, 1=legacy, 2=MCV2)
  *                            requires: n_encoder, int_value
@@ -149,7 +151,8 @@ public:
     Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t &canID,
           const uint16_t &motor_freq, const std::array<MotorConfig, 4> &motor_configs,
           int encoder_rate_hz = 20, int motor_update_rate_hz = 50,
-          bool limit_switches = false, bool enable_freshness = false);
+          bool limit_switches = false, bool enable_freshness = false,
+          uint8_t default_pid_type = 0, uint8_t scurve_profile = 0);
 
     ~Titan();
 
@@ -161,6 +164,13 @@ private:
     std::array<MotorConfig, 4> motor_configs_;
 
     float speeds_[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float target_rpm_[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    // per-motor pid type (0=OFF, 1=Manual, 2=S-Curve).
+    // resend_speeds(): pid 0 -> SetSpeed(speeds_); pid 1/2 -> SetTargetVelocity(target_rpm_).
+    uint8_t pid_type_[4] = {0, 0, 0, 0};
+    // One-shot position/hold: suppress velocity keepalives until next duty/velocity command.
+    std::array<bool, 4> position_active_ = {false, false, false, false};
+    std::array<bool, 4> cmd_rejected_warned_ = {false, false, false, false};
     bool enabled_ = false;
     bool limit_switches_enabled_ = false;
     bool freshness_enabled_ = false;
@@ -184,9 +194,12 @@ private:
 
     // command subscribers — always created regardless of encoder mode
     std::array<rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr, 4> cmd_subs_;
+    std::array<rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr, 4> rpm_cmd_subs_;
 
     rclcpp::TimerBase::SharedPtr encoder_timer_;
     rclcpp::TimerBase::SharedPtr watchdog_timer_;
+
+    void resume_motion_resend(int motor, bool all_motors);
 
     void cmd_callback(std::shared_ptr<studica_control::srv::SetData::Request> request,
                       std::shared_ptr<studica_control::srv::SetData::Response> response);

--- a/src/studica_control/include/studica_control/titan_component.hpp
+++ b/src/studica_control/include/studica_control/titan_component.hpp
@@ -60,7 +60,8 @@
  *                            requires: n_encoder, int_value
  *     autotune             — autotune duty->rpm feedforward curve, all motors (lifted / forward-only)
  *     autotune_symmetric   — symmetric back-and-forth autotune on the ground; signs from
- *                            each motor's invert_motor param (studica_params.yaml).
+ *                            each motor's invert_motor param (studica_params.yaml). Forward travel
+ *                            per point is capped by the titan.<sensor>.autotune_distance_m param.
  *     autotune_motor       — autotune one motor
  *                            requires: n_encoder
  *     set_motor_pid_type   — per-motor pid type (0=OFF, 1=legacy, 2=MCV2)
@@ -152,7 +153,8 @@ public:
           const uint16_t &motor_freq, const std::array<MotorConfig, 4> &motor_configs,
           int encoder_rate_hz = 20, int motor_update_rate_hz = 50,
           bool limit_switches = false, bool enable_freshness = false,
-          uint8_t default_pid_type = 0, uint8_t scurve_profile = 0);
+          uint8_t default_pid_type = 0, uint8_t scurve_profile = 0,
+          double autotune_distance_m = 1.0);
 
     ~Titan();
 
@@ -162,6 +164,9 @@ private:
     uint8_t canID_;
     uint16_t motor_freq_;
     std::array<MotorConfig, 4> motor_configs_;
+    // Autotune forward-distance cap (metres) sent to firmware before each autotune sweep.
+    // From the titan.<sensor>.autotune_distance_m param; clamped to 0.5-5.0 m.
+    float autotune_distance_m_ = 1.0f;
 
     float speeds_[4] = {0.0f, 0.0f, 0.0f, 0.0f};
     float target_rpm_[4] = {0.0f, 0.0f, 0.0f, 0.0f};

--- a/src/studica_control/src/components/titan_component.cpp
+++ b/src/studica_control/src/components/titan_component.cpp
@@ -43,6 +43,7 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         std::string enable_freshness_param   = "titan." + sensor + ".enable_freshness";
         std::string default_pid_type_param   = "titan." + sensor + ".default_pid_type";
         std::string scurve_profile_param      = "titan." + sensor + ".scurve_profile";
+        std::string autotune_distance_param   = "titan." + sensor + ".autotune_distance_m";
 
         control->declare_parameter<int> (can_id_param, -1);
         control->declare_parameter<int> (motor_freq_param, -1);
@@ -52,6 +53,7 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         control->declare_parameter<bool>(enable_freshness_param, false);
         control->declare_parameter<int> (default_pid_type_param, 0);
         control->declare_parameter<int> (scurve_profile_param, 0);   // 0=nav (symmetric S-curve), 1=teleop
+        control->declare_parameter<double>(autotune_distance_param, 1.0);  // autotune forward cap (m), 0.5-5.0
 
         uint8_t  can_id               = static_cast<uint8_t>(control->get_parameter(can_id_param).as_int());
         uint16_t motor_freq           = static_cast<uint16_t>(control->get_parameter(motor_freq_param).as_int());
@@ -61,6 +63,7 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         bool     enable_freshness     = control->get_parameter(enable_freshness_param).as_bool();
         uint8_t  default_pid_type     = static_cast<uint8_t>(control->get_parameter(default_pid_type_param).as_int());
         uint8_t  scurve_profile       = static_cast<uint8_t>(control->get_parameter(scurve_profile_param).as_int());
+        double   autotune_distance_m  = control->get_parameter(autotune_distance_param).as_double();
 
         std::array<MotorConfig, 4> motor_configs;
         for (int m = 0; m < 4; m++) {
@@ -85,7 +88,7 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         auto titan = std::make_shared<Titan>(vmx, sensor, can_id, motor_freq, motor_configs,
                                              encoder_rate_hz, motor_update_rate_hz,
                                              limit_switches, enable_freshness, default_pid_type,
-                                             scurve_profile);
+                                             scurve_profile, autotune_distance_m);
         titan_nodes.push_back(titan);
     }
 
@@ -99,9 +102,14 @@ Titan::Titan(const rclcpp::NodeOptions &options) : Node("titan_", options) {}
 Titan::Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t &canID,
              const uint16_t &motor_freq, const std::array<MotorConfig, 4> &motor_configs,
              int encoder_rate_hz, int motor_update_rate_hz, bool limit_switches, bool enable_freshness,
-             uint8_t default_pid_type, uint8_t scurve_profile)
+             uint8_t default_pid_type, uint8_t scurve_profile, double autotune_distance_m)
     : Node(name), vmx_(vmx), canID_(canID), motor_freq_(motor_freq), motor_configs_(motor_configs),
       limit_switches_enabled_(limit_switches), freshness_enabled_(enable_freshness) {
+
+    // Clamp the autotune distance cap to the supported range; the firmware applies its own bound too.
+    if (autotune_distance_m < 0.5) autotune_distance_m = 0.5;
+    if (autotune_distance_m > 5.0) autotune_distance_m = 5.0;
+    autotune_distance_m_ = static_cast<float>(autotune_distance_m);
 
     for (int i = 0; i < 4; i++)
         pid_type_[i] = default_pid_type;
@@ -388,13 +396,10 @@ void Titan::cmd(std::string params,
         response->message = "motor " + std::to_string(motor) + " sensitivity set to "
                             + std::to_string(request->initparams.int_value);
 
-    } else if (params == "set_scurve_profile") {
-        uint8_t profile = static_cast<uint8_t>(request->initparams.int_value);  // 0=nav, 1=teleop (global)
-        titan_->SetRampProfile(profile);
-        response->success = true;
-        response->message = std::string("scurve profile set to ") + (profile ? "teleop" : "nav");
-
     } else if (params == "autotune") {
+        // Push the configured forward-distance cap first; ignored by firmware on a forward-only
+        // (lifted) sweep, but keeps the device's value in sync with the param.
+        titan_->SetAutotuneDistance(autotune_distance_m_);
         titan_->AutotuneAll();
         response->success = true;
         response->message = "autotune started on all motors";
@@ -406,11 +411,16 @@ void Titan::cmd(std::string params,
             signs[i] = motor_configs_[i].invert_motor ? '-' : '+';
             signs_str += signs[i];
         }
+        // Forward travel per duty point is capped at autotune_distance_m_ (the on-ground sweep
+        // rolls forward to sample, then closed-loop returns home).
+        titan_->SetAutotuneDistance(autotune_distance_m_);
         titan_->AutotuneAll(signs);
         response->success = true;
-        response->message = "symmetric autotune started (" + signs_str + " from invert_motor)";
+        response->message = "symmetric autotune started (" + signs_str + " from invert_motor), cap "
+                            + std::to_string(autotune_distance_m_) + " m";
 
     } else if (params == "autotune_motor") {
+        titan_->SetAutotuneDistance(autotune_distance_m_);
         titan_->AutotuneMotor(motor);
         response->success = true;
         response->message = "autotune started on motor " + std::to_string(motor);

--- a/src/studica_control/src/components/titan_component.cpp
+++ b/src/studica_control/src/components/titan_component.cpp
@@ -13,13 +13,15 @@
  *     publishes /name/m_N/angle (degrees) at 20hz
  *
  * command topics (always active):
- *     subscribe /name/m_N/cmd (Float64, duty cycle -1.0 to 1.0)
+ *     subscribe /name/m_N/cmd      (Float64, duty -1.0 to 1.0, pid type 0)
+ *     subscribe /name/m_N/rpm_cmd  (Float64, target rpm, pid type 1 or 2)
  *
  * service: /name/titan_cmd (studica_control/SetData)
  *   see titan_component.h for the full command reference.
  */
 
 #include "studica_control/titan_component.hpp"
+#include <cmath>
 #include <thread>
 
 namespace studica_control {
@@ -39,6 +41,8 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         std::string motor_update_rate_param = "titan." + sensor + ".motor_update_rate_hz";
         std::string limit_switches_param      = "titan." + sensor + ".limit_switches";
         std::string enable_freshness_param   = "titan." + sensor + ".enable_freshness";
+        std::string default_pid_type_param   = "titan." + sensor + ".default_pid_type";
+        std::string scurve_profile_param      = "titan." + sensor + ".scurve_profile";
 
         control->declare_parameter<int> (can_id_param, -1);
         control->declare_parameter<int> (motor_freq_param, -1);
@@ -46,6 +50,8 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         control->declare_parameter<int> (motor_update_rate_param, 50);
         control->declare_parameter<bool>(limit_switches_param, false);
         control->declare_parameter<bool>(enable_freshness_param, false);
+        control->declare_parameter<int> (default_pid_type_param, 0);
+        control->declare_parameter<int> (scurve_profile_param, 0);   // 0=nav (symmetric S-curve), 1=teleop
 
         uint8_t  can_id               = static_cast<uint8_t>(control->get_parameter(can_id_param).as_int());
         uint16_t motor_freq           = static_cast<uint16_t>(control->get_parameter(motor_freq_param).as_int());
@@ -53,6 +59,8 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
         int      motor_update_rate_hz = control->get_parameter(motor_update_rate_param).as_int();
         bool     limit_switches       = control->get_parameter(limit_switches_param).as_bool();
         bool     enable_freshness     = control->get_parameter(enable_freshness_param).as_bool();
+        uint8_t  default_pid_type     = static_cast<uint8_t>(control->get_parameter(default_pid_type_param).as_int());
+        uint8_t  scurve_profile       = static_cast<uint8_t>(control->get_parameter(scurve_profile_param).as_int());
 
         std::array<MotorConfig, 4> motor_configs;
         for (int m = 0; m < 4; m++) {
@@ -76,7 +84,8 @@ std::vector<std::shared_ptr<rclcpp::Node>> Titan::initialize(rclcpp::Node *contr
 
         auto titan = std::make_shared<Titan>(vmx, sensor, can_id, motor_freq, motor_configs,
                                              encoder_rate_hz, motor_update_rate_hz,
-                                             limit_switches, enable_freshness);
+                                             limit_switches, enable_freshness, default_pid_type,
+                                             scurve_profile);
         titan_nodes.push_back(titan);
     }
 
@@ -89,9 +98,13 @@ Titan::Titan(const rclcpp::NodeOptions &options) : Node("titan_", options) {}
 
 Titan::Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t &canID,
              const uint16_t &motor_freq, const std::array<MotorConfig, 4> &motor_configs,
-             int encoder_rate_hz, int motor_update_rate_hz, bool limit_switches, bool enable_freshness)
+             int encoder_rate_hz, int motor_update_rate_hz, bool limit_switches, bool enable_freshness,
+             uint8_t default_pid_type, uint8_t scurve_profile)
     : Node(name), vmx_(vmx), canID_(canID), motor_freq_(motor_freq), motor_configs_(motor_configs),
       limit_switches_enabled_(limit_switches), freshness_enabled_(enable_freshness) {
+
+    for (int i = 0; i < 4; i++)
+        pid_type_[i] = default_pid_type;
 
     titan_ = std::make_shared<studica_driver::Titan>(canID_, motor_freq_, 1, vmx_);
 
@@ -107,7 +120,38 @@ Titan::Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t 
             prefix + "/cmd", 1,
             [this, i](std_msgs::msg::Float64::SharedPtr msg) {
                 if (!enabled_) return;
-                speeds_[i] = static_cast<float>(msg->data);  // store only — resend_speeds is the sole sender
+                if (pid_type_[i] != 0) {
+                    const double duty = msg->data;
+                    const bool significant = std::abs(duty) > 1e-4;
+                    if (!cmd_rejected_warned_[i]) {
+                        cmd_rejected_warned_[i] = true;
+                        RCLCPP_WARN(this->get_logger(),
+                                             "m_%d: ignoring /cmd duty=%.3f (pid type %u); "
+                                             "use /rpm_cmd or set pid type 0",
+                                             i, duty, pid_type_[i]);
+                    } else if (significant) {
+                        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                                             "m_%d: ignoring /cmd duty=%.3f (pid type %u); "
+                                             "use /rpm_cmd or set pid type 0",
+                                             i, duty, pid_type_[i]);
+                    }
+                    return;
+                }
+                speeds_[i] = static_cast<float>(msg->data);
+                position_active_[i] = false;
+            });
+
+        rpm_cmd_subs_[i] = this->create_subscription<std_msgs::msg::Float64>(
+            prefix + "/rpm_cmd", 1,
+            [this, i](std_msgs::msg::Float64::SharedPtr msg) {
+                if (!enabled_) return;
+                if (pid_type_[i] == 0) {
+                    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                                         "m_%d: rpm_cmd ignored; set pid type 1 or 2 first", i);
+                    return;
+                }
+                target_rpm_[i] = static_cast<float>(msg->data);
+                position_active_[i] = false;
             });
 
         // feedback publishers — depend on encoder mode
@@ -148,7 +192,10 @@ Titan::Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t 
         if (motor_configs_[i].invert_rpm)     titan_->InvertMotorRPM(i);
     }
 
-    titan_->SetPIDType(0);
+    titan_->SetPIDType(default_pid_type);
+
+    // Velocity ramp profile (MCV2): 0=nav (symmetric S-curve), 1=teleop (smooth accel, instant decel).
+    titan_->SetRampProfile(scurve_profile);
 
     // The Titan requires ~1s after initial CONFIG_MOTOR frames before it will
     // accept the enable command. See drivers/examples/titan_example/titan_example.cpp.
@@ -157,10 +204,22 @@ Titan::Titan(std::shared_ptr<VMXPi> vmx, const std::string &name, const uint8_t 
     titan_->Enable(true);
     enabled_ = true;
 
-    RCLCPP_INFO(this->get_logger(), "titan ready. can_id: %d, freq: %d hz", canID_, motor_freq_);
+    RCLCPP_INFO(this->get_logger(), "titan ready. can_id: %d, freq: %d hz, pid_type: %u, scurve_profile: %u (%s)",
+                canID_, motor_freq_, static_cast<unsigned>(default_pid_type),
+                static_cast<unsigned>(scurve_profile), scurve_profile ? "teleop" : "nav");
 }
 
 Titan::~Titan() {}
+
+void Titan::resume_motion_resend(int motor, bool all_motors)
+{
+    if (all_motors) {
+        for (int i = 0; i < 4; i++)
+            position_active_[i] = false;
+    } else {
+        position_active_[motor] = false;
+    }
+}
 
 
 void Titan::cmd_callback(std::shared_ptr<studica_control::srv::SetData::Request> request,
@@ -184,33 +243,65 @@ void Titan::cmd(std::string params,
         response->message = "titan enabled";
 
     } else if (params == "disable") {
-        for (int i = 0; i < 4; i++) speeds_[i] = 0.0f;
+        resume_motion_resend(0, true);
+        for (int i = 0; i < 4; i++) {
+            speeds_[i] = 0.0f;
+            target_rpm_[i] = 0.0f;
+        }
         enabled_ = false;
         titan_->Enable(false);
         response->success = true;
         response->message = "titan disabled";
 
     } else if (params == "set_speed") {
-        float speed = request->initparams.speed;
-        speeds_[motor] = speed;
-        titan_->SetSpeed(motor, speed);
-        response->success = true;
-        response->message = "motor " + std::to_string(motor) + " speed set to " + std::to_string(speed);
+        if (pid_type_[motor] != 0) {
+            response->success = false;
+            response->message = "motor " + std::to_string(motor) + " is in pid type "
+                                + std::to_string(pid_type_[motor])
+                                + "; switch to pid type 0 before open-loop duty commands";
+        } else {
+            float speed = request->initparams.speed;
+            resume_motion_resend(motor, false);
+            speeds_[motor] = speed;
+            titan_->SetSpeed(motor, speed);
+            response->success = true;
+            response->message = "motor " + std::to_string(motor) + " speed set to " + std::to_string(speed);
+        }
 
     } else if (params == "set_speed_all") {
+        for (int i = 0; i < 4; i++) {
+            if (pid_type_[i] != 0) {
+                response->success = false;
+                response->message = "motor " + std::to_string(i) + " is in pid type "
+                                    + std::to_string(pid_type_[i])
+                                    + "; switch to pid type 0 before open-loop duty commands";
+                return;
+            }
+        }
         float speed = request->initparams.speed;
-        for (int i = 0; i < 4; i++) speeds_[i] = speed;
+        resume_motion_resend(0, true);
+        for (int i = 0; i < 4; i++)
+            speeds_[i] = speed;
         titan_->SetSpeedAll(static_cast<double>(speed));
         response->success = true;
         response->message = "all motors set to " + std::to_string(speed);
 
     } else if (params == "stop") {
-        speeds_[motor] = 0.0f;
-        titan_->SetSpeed(motor, 0.0);
+        resume_motion_resend(motor, false);
+        if (pid_type_[motor] == 0) {
+            speeds_[motor] = 0.0f;
+            titan_->SetSpeed(motor, 0.0);
+        } else {
+            target_rpm_[motor] = 0.0f;
+            titan_->SetTargetVelocity(motor, 0.0f);
+        }
         response->success = true;
         response->message = "motor " + std::to_string(motor) + " stopped";
 
     } else if (params == "disable_motor") {
+        speeds_[motor] = 0.0f;
+        target_rpm_[motor] = 0.0f;
+        resume_motion_resend(motor, false);
         titan_->DisableMotor(motor);
         response->success = true;
         response->message = "motor " + std::to_string(motor) + " disabled";
@@ -223,35 +314,73 @@ void Titan::cmd(std::string params,
     // --- closed loop velocity / position control (titan2 firmware) ---
 
     } else if (params == "set_target_velocity") {
-        float rpm = request->initparams.speed;
-        titan_->SetTargetVelocity(motor, rpm);
-        response->success = true;
-        response->message = "motor " + std::to_string(motor) + " target velocity set to " + std::to_string(rpm) + " rpm";
+        // closed-loop only: firmware ignores SetTargetVelocity when pid type is OFF
+        if (pid_type_[motor] == 0) {
+            response->success = false;
+            response->message = "motor " + std::to_string(motor)
+                                + " is in pid type 0 (OFF); set pid type 1 or 2 before set_target_velocity";
+        } else {
+            float rpm = request->initparams.speed;
+            resume_motion_resend(motor, false);
+            target_rpm_[motor] = rpm;
+            titan_->SetTargetVelocity(motor, rpm);
+            response->success = true;
+            response->message = "motor " + std::to_string(motor) + " target velocity set to " + std::to_string(rpm) + " rpm";
+        }
 
     } else if (params == "set_target_distance") {
-        titan_->SetTargetDistance(motor, static_cast<int32_t>(request->initparams.int_value));
-        response->success = true;
-        response->message = "motor " + std::to_string(motor) + " target distance set to "
-                            + std::to_string(request->initparams.int_value) + " counts";
+        if (pid_type_[motor] == 0) {
+            response->success = false;
+            response->message = "motor " + std::to_string(motor)
+                                + " is in pid type 0 (OFF); set pid type 1 or 2 before set_target_distance";
+        } else {
+            position_active_[motor] = true;
+            titan_->SetTargetDistance(motor, static_cast<int32_t>(request->initparams.int_value));
+            response->success = true;
+            response->message = "motor " + std::to_string(motor) + " target distance set to "
+                                + std::to_string(request->initparams.int_value) + " counts";
+        }
 
     } else if (params == "set_target_angle") {
-        titan_->SetTargetAngle(motor, static_cast<double>(request->initparams.speed));
-        response->success = true;
-        response->message = "motor " + std::to_string(motor) + " target angle set to "
-                            + std::to_string(request->initparams.speed) + " degrees";
+        if (pid_type_[motor] == 0) {
+            response->success = false;
+            response->message = "motor " + std::to_string(motor)
+                                + " is in pid type 0 (OFF); set pid type 1 or 2 before set_target_angle";
+        } else {
+            position_active_[motor] = true;
+            titan_->SetTargetAngle(motor, static_cast<double>(request->initparams.speed));
+            response->success = true;
+            response->message = "motor " + std::to_string(motor) + " target angle set to "
+                                + std::to_string(request->initparams.speed) + " degrees";
+        }
 
     } else if (params == "set_position_hold") {
-        titan_->SetPositionHold(motor, request->initparams.hold);
-        response->success = true;
-        response->message = "motor " + std::to_string(motor) + " position hold "
-                            + std::string(request->initparams.hold ? "enabled" : "disabled");
+        if (pid_type_[motor] == 0) {
+            response->success = false;
+            response->message = "motor " + std::to_string(motor)
+                                + " is in pid type 0 (OFF); set pid type 1 or 2 before set_position_hold";
+        } else {
+            position_active_[motor] = request->initparams.hold;
+            if (!request->initparams.hold)
+                resume_motion_resend(motor, false);
+            titan_->SetPositionHold(motor, request->initparams.hold);
+            response->success = true;
+            response->message = "motor " + std::to_string(motor) + " position hold "
+                                + std::string(request->initparams.hold ? "enabled" : "disabled");
+        }
 
     // --- pid tuning (titan2 firmware) ---
-
     } else if (params == "set_pid_type") {
-        titan_->SetPIDType(static_cast<uint8_t>(request->initparams.int_value));
+        uint8_t type = static_cast<uint8_t>(request->initparams.int_value);
+        titan_->SetPIDType(type);
+        for (int i = 0; i < 4; i++) {
+            pid_type_[i] = type;
+            position_active_[i] = false;
+            if (type == 0)
+                target_rpm_[i] = 0.0f;
+        }
         response->success = true;
-        response->message = "pid type set to " + std::to_string(request->initparams.int_value);
+        response->message = "pid type set to " + std::to_string(type);
 
     } else if (params == "set_sensitivity") {
         titan_->SetSensitivity(motor, static_cast<uint8_t>(request->initparams.int_value));
@@ -259,10 +388,27 @@ void Titan::cmd(std::string params,
         response->message = "motor " + std::to_string(motor) + " sensitivity set to "
                             + std::to_string(request->initparams.int_value);
 
+    } else if (params == "set_scurve_profile") {
+        uint8_t profile = static_cast<uint8_t>(request->initparams.int_value);  // 0=nav, 1=teleop (global)
+        titan_->SetRampProfile(profile);
+        response->success = true;
+        response->message = std::string("scurve profile set to ") + (profile ? "teleop" : "nav");
+
     } else if (params == "autotune") {
         titan_->AutotuneAll();
         response->success = true;
         response->message = "autotune started on all motors";
+
+    } else if (params == "autotune_symmetric") {
+        char signs[4];
+        std::string signs_str;
+        for (int i = 0; i < 4; i++) {
+            signs[i] = motor_configs_[i].invert_motor ? '-' : '+';
+            signs_str += signs[i];
+        }
+        titan_->AutotuneAll(signs);
+        response->success = true;
+        response->message = "symmetric autotune started (" + signs_str + " from invert_motor)";
 
     } else if (params == "autotune_motor") {
         titan_->AutotuneMotor(motor);
@@ -270,10 +416,15 @@ void Titan::cmd(std::string params,
         response->message = "autotune started on motor " + std::to_string(motor);
 
     } else if (params == "set_motor_pid_type") {
-        titan_->SetMotorPIDType(motor, static_cast<uint8_t>(request->initparams.int_value));
+        uint8_t type = static_cast<uint8_t>(request->initparams.int_value);
+        titan_->SetMotorPIDType(motor, type);
+        pid_type_[motor] = type;
+        position_active_[motor] = false;
+        if (type == 0)
+            target_rpm_[motor] = 0.0f;
         response->success = true;
         response->message = "motor " + std::to_string(motor) + " pid type set to "
-                            + std::to_string(request->initparams.int_value);
+                            + std::to_string(type);
 
     // --- encoder configuration ---
 
@@ -499,7 +650,12 @@ void Titan::publish_encoders() {
 void Titan::resend_speeds() {
     if (!enabled_) return;
     for (int i = 0; i < 4; i++) {
-        titan_->SetSpeed(i, speeds_[i]); 
+        if (position_active_[i])
+            continue;
+        if (pid_type_[i] == 0)
+            titan_->SetSpeed(i, speeds_[i]);
+        else
+            titan_->SetTargetVelocity(i, target_rpm_[i]);
     }
 }
 


### PR DESCRIPTION
- Added new Titan params:
- - `scurve_profile`, where 1 is for teleop and 0 is for NAV. The teleop and NAV profiles have the same acceleration smoothing, but teleop has faster brakikng
- - `autotune_distance_m` sets a distance limit for the new symmetric autotune feature
- - `default_pid_type` sets the starting PID mode, so a service call to set PID mode does not have to be used on  startup
- `autotune_symmetric` is the new service command that runs on-ground autotune. the robot will drive forward and backward, taking RPM measurements at different applied duties to build a feedforward table. The existing `autotune` command is intended can be with the robot lifted in the air, but not recommended as it is less accurate. 